### PR TITLE
4.9.0：屁岱看图与资料站、小部件重做、图书馆多校区

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 yeliqin666
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,135 +1,89 @@
-<h1 align="center">🌟✨⭐ 求 Star！！！⭐✨🌟</h1>
-
 # 岱宗盒子
 
 <p align="center">
   <img src="https://img.shields.io/badge/platform-Android-green?logo=android" alt="Android" />
   <img src="https://img.shields.io/badge/minSdk-31%20(Android%2012)-blue" alt="minSdk 31" />
-  <img src="https://img.shields.io/badge/version-4.5-orange" alt="version 4.5" />
+  <img src="https://img.shields.io/badge/version-4.9.0-orange" alt="version 4.9.0" />
   <img src="https://img.shields.io/badge/license-MIT-lightgrey" alt="MIT License" />
 </p>
 
-面向西安交通大学学生的 Android 校园工具箱。项目使用 Kotlin 与 Jetpack Compose 原生开发，直接访问教务、图书馆、校园卡、思源学堂等学校系统，不依赖自建业务中转服务器。
+面向西安交通大学学生的 Android 校园工具箱。使用 Kotlin 与 Jetpack Compose 原生开发，便捷使用教务、图书馆、校园卡、思源学堂等学校服务，**不经过任何自建业务中转服务器**——账号凭据与数据只在设备和学校系统之间流动。
 
-应用内置可自定义名称的校园 AI 助手「**屁岱**」。配置兼容 OpenAI API 格式的模型服务后，它可以调用本地校园工具，查询课表、成绩、考试、空闲教室、校园卡、通知、思源学堂、体测等信息，并以自然语言和卡片形式回答；也可调用学校的「交晓智」补充校内政策与办事知识。
+应用内置可自定义名称的校园 AI 助手「**屁岱**」。配置任意兼容 OpenAI API 格式的模型服务后，可查询课程安排、成绩、空闲教室、校园卡、通知、思源学堂、体测、仲英学辅资料等信息，并以自然语言和卡片形式作答；也可转调学校的「交晓智」补充校内政策与办事知识。
 
-> AI 对话可能包含个人校园数据。请使用可信的模型服务并妥善保管 API Key。
+> [!IMPORTANT]
+> 屁岱的请求会把相关校园数据发给你配置的模型服务。请使用可信的服务商，并妥善保管 API Key。
+> 推荐使用`deepseek-flash`模型。
 
 ---
 
-## 4.5 亮点
+## 目录
 
-| 能力 | 说明 |
+- [特性](#特性)
+- [屁岱（AI 助手）](#屁岱ai-助手)
+- [技术栈](#技术栈)
+- [本地构建](#本地构建)
+- [发版](#发版)
+- [参与贡献](#参与贡献)
+- [使用须知](#使用须知)
+- [相关项目](#相关项目)
+- [许可](#许可)
+
+---
+
+## 特性
+
+| 模块 | 能力 |
 |------|------|
-| 🏠 双首页主题 | 图标主题以分类宫格展示全部能力；卡片主题聚合下节课、校园卡余额、本周出勤率、待评教、体测、作业等实时状态 |
-| 🔔 主动提醒 | 屁岱可提醒余额不足、新成绩、临近上课和教务处新通知，并支持在设置中关闭 |
-| 🎓 学籍档案 | 「我的」页展示证件照、书院、学院、专业、班级、校区，以及辅导员和班主任联系方式 |
-| 📥 下载管理 | 仲英学辅资料站支持文件下载；思源课件、课程回放、成绩单和资料站文件统一管理，支持多选删除 |
-| 👥 多账号 | 支持添加、切换、改密和删除账号，各账号的课表、成绩、对话、校园卡数据相互隔离 |
-| 📱 校外访问 | 修复移动交大 WebVPN 访问链路，网页内可调用相机；统一认证支持 MFA 与失败退避 |
+| 界面UI | MIUIX原生UI，结合自写的大卡片主题/彩虹图标主题与采集系统颜色、全局深色模式，风格优雅大气、直观易用 |
+| 账号与认证 | CAS 登录、MFA验证码、多账号隔离、WebVPN 自动切换、登录诊断与请求限流 |
+| 日程 | 多学期课表、考试安排、教材信息、自定义日程、桌面小组件、自由导出 |
+| 成绩与学籍 | 未评教成绩查询、GPA 计算、学籍档案 |
+| 考勤 | 本科生 / 研究生考勤查询、出勤统计与日期流水 |
+| 教学空间 | 空闲教室查询、全校课程检索、教师信息 |
+| 校园生活 | 校园卡、付款码、加餐券、体育场馆预订 |
+| 图书馆 | 三校区座位查询、空位推荐、预约、换座、取消与签到 |
+| 思源学堂 | 课程、活动、作业、评分、课件与附件查看下载 |
+| 课程回放 | TronClass 多机位视频播放、课件下载与统一下载管理 |
+| 仲英学辅 | 资料检索、目录浏览与文件下载 |
+| 校园信息 | 教务处 / 学院通知聚合、校园黄页、体测成绩、电子教材、校历 |
+| 评教 | GSTE 与常规评教（即将更换新系统） |
+
+
+多账号下，各账号的课表、成绩、对话与校园卡数据相互隔离。
+
+> [!NOTE]
+> 学校接口和开放范围可能随时变化，失效请在 `announce` 分支提 PR。
 
 ---
 
-## 界面预览
+## 屁岱（AI 助手）
 
-下面用 11 组、30 个真实界面串起岱宗盒子的主要使用场景：从一天的课程安排，到成绩、校园卡、图书馆，再到能实际调用这些能力的校园助手。
+屁岱把自然语言请求翻译成校园工具调用，而不是靠模型凭记忆作答——课表、成绩、余额、座位这类事实一律以工具返回为准。
 
-> 为保护隐私，身份、成绩、体测和付款码等页面均已替换为虚构 Demo 数据；示例姓名、照片、学号、课程和数值不对应任何真实学生，付款码也不是有效凭证。
+**对接方式**：DeepSeek、OpenAI，或任意 OpenAI 兼容端点（含中转）。需自备 API Key。
 
-### 从首页出发
+**主要能力**
 
-图标主题把常用能力收进一张清晰的功能地图；移动交大则直接嵌入应用，校内服务不必在多个入口之间来回切换。
+- 多会话、流式回复、Markdown 渲染，结果同时以卡片呈现（课表、成绩、空教室、考勤、校园卡等）
+- 图片输入：发课表截图、通知照片、题目直接提问（需模型支持视觉，如 `deepseek-flash`、GPT-4o 系）
+- 联网搜索与网页阅读，转述时标注来源并区分官方通知与搜索结果
+- 调用系统闹钟与日历，交由系统应用确认后创建
+- 记住用户偏好，跨会话生效
+- 转调「交晓智」补充校内政策与办事知识
+- 能力开关：每一类工具都可在设置中单独关闭，关闭后模型不会看到对应工具
 
-![图标主题首页与移动交大](artwork/readme/01-home-and-mobile.png)
+**隐私边界**
 
-### 一个日程，装下整个学期
-
-课表、教材与考试安排集中展示。既能快速确认下一节课，也能查看课程细节、考试时间与地点。
-
-![课程表、教材与考试安排](artwork/readme/02-schedule-center.png)
-
-### 学籍与考勤，一眼有数
-
-个人档案聚合基础学籍信息，考勤记录则按日期呈现出勤流水，让分散在不同系统里的信息回到同一个页面。
-
-![个人学籍档案与考勤记录](artwork/readme/03-profile-and-attendance.png)
-
-### 学习资料，随用随取
-
-电子教材和仲英学辅资料站覆盖教材阅读、资料检索与文件下载，减少在网页和文件夹之间反复寻找的成本。
-
-![电子教材与仲英学辅资料](artwork/readme/04-learning-resources.png)
-
-### 通知与黄页，不再靠翻群聊
-
-校园通知集中浏览，校园黄页快速检索常用联系方式。找消息和找人，都可以少走几步。
-
-![校园通知与校园黄页](artwork/readme/05-notices-and-directory.png)
-
-### 校园卡与加餐券
-
-余额、消费流水、付款码和加餐券统一管理。高频校园支付场景被放进更短、更直接的操作路径。
-
-![校园卡付款、余额流水与加餐券](artwork/readme/06-card-and-coupons.png)
-
-### 空间与体测
-
-空闲教室帮助临时自习，图书馆提供座位相关能力，体测页面则集中呈现项目成绩与总评。
-
-![空闲教室、图书馆与体测成绩](artwork/readme/07-spaces-and-fitness.png)
-
-### 成绩，不只是一串数字
-
-成绩查询适合快速浏览，成绩报表则提供更完整的学期视图与统计信息。示例课程和分数均为虚构数据。
-
-![成绩查询与成绩报表](artwork/readme/08-grades.png)
-
-### 校园工具，也可以保持轻巧
-
-从全校课程查询、评教到 WebVPN 与移动服务，岱宗盒子把那些“偶尔需要、需要时又很急”的入口放在手边。
-
-![课程查询、评教、WebVPN 与校园工具](artwork/readme/09-campus-tools.png)
-
-### AI 也要懂校园语境
-
-除了通用模型，应用还接入学校的交晓智，并支持思源学堂等校园知识与学习场景，让回答更贴近校内实际。
-
-![交晓智、思源学堂与校园知识能力](artwork/readme/10-ai-knowledge.png)
-
-### 屁岱：不止陪聊，还能办事
-
-屁岱可以把自然语言请求转成校园工具调用：查课表、看成绩、找通知、读考勤、搜黄页，也能继续调用系统能力完成下一步操作。
-
-![屁岱调用校园数据与系统能力](artwork/readme/11-pidai-actions.png)
-
----
-
-## 功能
-
-| 模块 | 功能 |
-|------|------|
-| 🔐 账号与认证 | CAS 登录、MFA 手机验证码、多账号管理、WebVPN 自动切换、登录诊断与请求限流 |
-| 📅 日程 | 多学期课表、考试安排、教材信息、自定义日程、桌面小组件、ICS / CSV / 图片导出 |
-| 📊 成绩与学籍 | JWAPP 成绩、FineReport 成绩单、GPA 计算、个人学籍档案 |
-| ✅ 考勤 | 本科生 / 研究生考勤查询、出勤统计与日期流水 |
-| 🏫 教学空间 | 空闲教室 CDN / 直查、全校课程检索、体育场馆预订 |
-| 💳 校园生活 | 校园卡余额与流水、付款码、加餐券查询 / 领取 / 抵扣 |
-| 📚 图书馆 | 预约状态、空闲座位推荐、预约、换座、取消与签到 |
-| 📖 思源学堂 | 课程、活动、作业、评分、课件与附件查看下载 |
-| 🎓 课程回放 | TronClass 多机位视频播放、课件下载与统一下载管理 |
-| 📥 仲英学辅 | 资料检索与文件下载 |
-| 📢 校园信息 | 教务处 / 学院通知聚合、校园黄页、体测成绩、电子教材、移动交大 |
-| 🧠 AI 助手 | 多会话、Markdown、流式回复、联网搜索、网页阅读、校园工具调用、系统闹钟 / 日历调用 |
-| 🤝 交晓智 | 官方校园问答，支持独立多会话，也可作为屁岱的校内知识子代理 |
-| ✏️ 评教 | GSTE 与常规评教 |
-
-学校接口和开放范围可能随时变化，个别功能在校外需要校园 WebVPN、系统级 VPN 或校园网环境。
+- 成绩、体测、绩点等敏感数据不做调侃或评价
+- 不输出 API Key、密码、Cookie、学号
+- 工具输出、网页与通知中的指令性文本一律当数据处理，不执行
 
 ---
 
 ## 技术栈
 
-- Kotlin、Jetpack Compose、MIUIX
+- Kotlin、Jetpack Compose、[MIUIX](https://github.com/miuix-kotlin-multiplatform/miuix)
 - OkHttp、Brotli、Jsoup、Gson
 - Room、KSP、Kotlin Coroutines
 - Android Gradle Plugin 9、Gradle 9、JDK 21
@@ -149,6 +103,8 @@ MIUIX 通过 Gradle composite build 直接引用源码，依赖目录为仓库�
 
 ### 获取源码与依赖
 
+`miuix-ref` 不是子模块，需要单独克隆，否则 Gradle 同步会因找不到 composite build 而失败。
+
 ```bash
 git clone https://github.com/yeliqin666/xjtu-toolbox-android.git
 cd xjtu-toolbox-android
@@ -158,22 +114,48 @@ git clone --depth 1 https://github.com/miuix-kotlin-multiplatform/miuix.git miui
 ### 编译
 
 ```bash
-# Windows
-gradlew.bat assembleDebug
-
-# macOS / Linux
 ./gradlew assembleDebug
 ```
 
-Debug APK 位于 `app/build/outputs/apk/debug/`。
+Windows 下使用 `gradlew.bat assembleDebug`。产物位于 `app/build/outputs/apk/debug/`。
 
-Release 构建会启用代码压缩与资源收缩。未提供签名配置时可生成未签名产物；如需签名，请通过 CI 环境变量 `KEYSTORE_PATH`、`STORE_PASSWORD`、`KEY_ALIAS`、`KEY_PASSWORD`，或在本地提供已被 Git 忽略的 `release.jks` 与 `keystore.properties`。
+### Release 构建
+
+Release 会启用代码压缩与资源收缩。未提供签名配置时生成未签名产物；如需签名，通过环境变量 `KEYSTORE_PATH`、`STORE_PASSWORD`、`KEY_ALIAS`、`KEY_PASSWORD` 提供，或在本地放置被 Git 忽略的 `release.jks` 与 `keystore.properties`。
 
 ```bash
 ./gradlew assembleRelease
 ```
 
-GitHub Actions 会在推送到 `main` 后使用签名密钥构建 Release APK，并根据 `versionName` 创建或更新对应的 GitHub / Gitee Release。发版前需先同步更新 `versionName`、`versionCode` 与 `AppChangelog.kt`。
+### 测试
+
+```bash
+./gradlew testDebugUnitTest
+```
+
+---
+
+## 发版
+
+推送到 `main` 后，GitHub Actions 会用签名密钥构建 Release APK，并按 `versionName` 创建或更新对应的 GitHub / Gitee Release。Release 说明由 `AppChangelog.kt` 自动生成。
+
+发版前必须同步更新三处，缺一不可：
+
+1. `app/build.gradle.kts` 的 `versionName` 与 `versionCode`
+2. `app/src/main/java/com/xjtu/toolbox/util/AppChangelog.kt` 最前面追加对应版本条目（编译期会校验）
+3. 如有必要，更新本文件的版本徽章
+
+`AppChangelog.kt` 中 `issues` 字段写的是**发版时仍然存在的问题**，每条一句用户看得懂的话；它会原样显示在应用内的更新弹窗里，不要填 issue 编号。
+
+校园系统临时故障或维护公告不走发版流程：对 `announce` 分支的 `bulletin.json` 提 PR，或直接开一个「校园系统状态」Issue。
+
+---
+
+## 参与贡献
+
+欢迎 Issue 和 PR。提问题时请说明应用版本、机型系统、涉及模块与复现步骤；**不要粘贴账号、密码、Cookie 或 API Key**。
+
+学校系统接口变动、系统维护是功能失效最主要的来源。如果你发现问题，欢迎直接提 issue。
 
 ---
 
@@ -181,17 +163,21 @@ GitHub Actions 会在推送到 `main` 后使用签名密钥构建 Release APK，
 
 - 本项目仅供学习与个人校园信息管理使用，请遵守学校各系统的使用规则。
 - 学校系统接口可能调整，功能可用性以实际情况为准。
-- 请勿高频请求或尝试绕过验证码、访问控制等安全机制。
-- API Key、账号凭据和下载的个人资料均应妥善保管。
+- 请勿高频请求，或尝试绕过验证码、访问控制等安全机制。
+- API Key、账号凭据与下载的个人资料均应妥善保管。
 - AI 生成内容与交晓智结果可能有误，重要信息请以学校官方渠道为准。
+- 本项目为学生个人作品，非西安交通大学官方产品，与学校无隶属关系。
 
 ---
 
-## 友情项目
+## 相关项目
 
-- [XJTUToolBox](https://github.com/yan-xiaoo/XJTUToolBox.git)
+- [XJTUToolBox](https://github.com/yan-xiaoo/XJTUToolBox) —— 桌面端仙交百宝箱
 - [XJTU-Course-Genius](https://github.com/Hz162/XJTU-Course-Genius)
+- [zyxf](https://github.com/Guochaoo/zyxf) —— 仲英学辅资料站
 
 ---
 
-**License**：MIT
+## 许可
+
+[MIT](LICENSE)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.xjtu.toolbox"
         minSdk = 31
         targetSdk = 36
-        versionCode = 55
-        versionName = "4.8.6"
+        versionCode = 56
+        versionName = "4.9.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/xjtu/toolbox/MainActivity.kt
+++ b/app/src/main/java/com/xjtu/toolbox/MainActivity.kt
@@ -3526,7 +3526,7 @@ private fun HomeTab(
                 val startDate = if (!startDateStr.isNullOrBlank()) runCatching { java.time.LocalDate.parse(startDateStr) }.getOrNull() else null
                 val today = java.time.LocalDate.now()
                 val weekNumber = if (startDate != null) {
-                    ((java.time.temporal.ChronoUnit.DAYS.between(startDate, today) / 7) + 1).toInt()
+                    com.xjtu.toolbox.schedule.TermWeeks.weekOf(startDate, today)
                         .takeIf { it in 1..25 } ?: 0
                 } else {
                     0
@@ -3545,7 +3545,7 @@ private fun HomeTab(
                     val targetDate = today.plusDays(offset.toLong())
                     if (holidayDates.containsKey(targetDate)) continue
 
-                    val targetWeek = ((java.time.temporal.ChronoUnit.DAYS.between(startDate, targetDate) / 7) + 1).toInt()
+                    val targetWeek = com.xjtu.toolbox.schedule.TermWeeks.weekOf(startDate, targetDate)
                     if (targetWeek <= 0) continue
                     val daySchedules = allSchedules
                         .filter { it.dayOfWeek == targetDate.dayOfWeek.value && it.isInWeek(targetWeek) }

--- a/app/src/main/java/com/xjtu/toolbox/agent/AgentConfigStore.kt
+++ b/app/src/main/java/com/xjtu/toolbox/agent/AgentConfigStore.kt
@@ -6,6 +6,20 @@ import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKeys
 import com.xjtu.toolbox.account.AccountContext
 
+/**
+ * 把存下来的思考强度收敛到本地支持的档位。
+ *
+ * DeepSeek 的别名（`minimal`→low、`medium`/`xhigh`→high）也认：用户可能在别处见过这些
+ * 写法，或者以后服务端改口径。认不出的一律回落到「自动」——下发一个服务端不认的值，
+ * 整个请求会 400，表现是屁岱一句话都不说。
+ */
+internal fun normalizeReasoningEffort(raw: String?): String = when (raw?.trim()?.lowercase()) {
+    "minimal", AgentConfig.REASONING_LOW -> AgentConfig.REASONING_LOW
+    "medium", "xhigh", AgentConfig.REASONING_HIGH -> AgentConfig.REASONING_HIGH
+    AgentConfig.REASONING_MAX -> AgentConfig.REASONING_MAX
+    else -> AgentConfig.REASONING_AUTO
+}
+
 data class AgentConfig(
     val provider: String = PROVIDER_DEEPSEEK,
     val apiKey: String = "",
@@ -35,7 +49,9 @@ data class AgentConfig(
         get() = model.ifBlank {
             when (provider) {
                 PROVIDER_OPENAI -> "gpt-4o-mini"
-                else -> "deepseek-v4-flash"
+                // `deepseek-v4-flash` 是旧名，模型已退役，请求被转到 V4.1-Flash 计费。
+                // 直接用现名，免得日后旧名真的下线。
+                else -> "deepseek-flash"
             }
         }
 
@@ -46,7 +62,9 @@ data class AgentConfig(
         const val PROVIDER_DEEPSEEK = "deepseek"
         const val PROVIDER_OPENAI = "openai"
         const val PROVIDER_CUSTOM = "custom"
+        /** 不下发 `reasoning_effort`，由服务端按模型默认档跑。不是 DeepSeek 的合法取值。 */
         const val REASONING_AUTO = "auto"
+        const val REASONING_LOW = "low"
         const val REASONING_HIGH = "high"
         const val REASONING_MAX = "max"
         const val SEARCH_AUTO = "auto"
@@ -69,7 +87,19 @@ data class AgentConfig(
         const val STYLE_PROFESSIONAL = "professional"
 
         val PROVIDERS = listOf(PROVIDER_DEEPSEEK, PROVIDER_OPENAI, PROVIDER_CUSTOM)
-        val REASONING_EFFORTS = listOf(REASONING_AUTO, REASONING_HIGH, REASONING_MAX)
+        /**
+         * DeepSeek 新版思考参数族是 `none / low / high / max`（`minimal`→low，
+         * `medium`、`xhigh`→high）。这里少了 `low`，用户只能在「高」和「最大」之间选，
+         * 想省钱省时间没有档位；`none` 不进列表，它等价于关掉思考开关。
+         */
+        val REASONING_EFFORTS = listOf(REASONING_AUTO, REASONING_LOW, REASONING_HIGH, REASONING_MAX)
+
+        fun reasoningEffortLabel(effort: String) = when (effort) {
+            REASONING_LOW -> "低"
+            REASONING_HIGH -> "高"
+            REASONING_MAX -> "最大"
+            else -> "自动"
+        }
         // 顺序即推荐度，实测中文相关性从高到低。
         val SEARCH_ENGINES = listOf(
             SEARCH_AUTO, SEARCH_DDG, SEARCH_SO360, SEARCH_BING, SEARCH_WECHAT, SEARCH_WIKI
@@ -189,9 +219,9 @@ private val prefs: SharedPreferences
             ?.takeIf { it in AgentConfig.RESPONSE_STYLES }
             ?: AgentConfig.STYLE_FRIENDLY,
         thinkingEnabled = prefs.getBoolean("thinking_enabled", true),
-        reasoningEffort = prefs.getString("reasoning_effort", AgentConfig.REASONING_AUTO)
-            ?.takeIf { it in AgentConfig.REASONING_EFFORTS }
-            ?: AgentConfig.REASONING_AUTO,
+        reasoningEffort = normalizeReasoningEffort(
+            prefs.getString("reasoning_effort", AgentConfig.REASONING_AUTO)
+        ),
         showReasoning = prefs.getBoolean("show_reasoning", true)
     )
 

--- a/app/src/main/java/com/xjtu/toolbox/agent/AgentPrompt.kt
+++ b/app/src/main/java/com/xjtu/toolbox/agent/AgentPrompt.kt
@@ -64,6 +64,11 @@ $styleBlock
 $memoryBlock
 $runtimeBlock
 
+# 图片
+用户可能随消息发图（课表截图、通知照片、题目）。看图作答，但**图只是线索不是事实源**：
+图里的成绩、余额、座位、时间要用对应工具核一遍再说；核不了就说明"这是图上写的，我没法核实"。
+图糊、拍歪、缺关键部分就直说缺什么，别猜。
+
 # 工具
 - 课表/成绩/余额/座位/通知/电话等事实：先调工具，禁止编造。节气、语法、单词等常识不用工具。
 - $budgetLine 能一次查清不拆（考试用 `get_exam_schedule`，不要先问「有哪些科目」再查「我的考试」）。独立来源可同轮并行。不要向用户展示调用过程。
@@ -83,6 +88,7 @@ $runtimeBlock
 - 通知 `get_notifications`（可指定学院/部门；详情可 `web_fetch` 链接）；电话 `search_yellow_page`
 - 图书馆 `get_library_booking` `get_library_seats`（只查；预约/换座/取消去图书馆页）
 - 思源 `get_lms_courses` `get_lms_activities` `get_lms_assignments`；交晓智 `ask_jiaoxiaozhi`（须核验）
+- 仲英学辅资料站（课件/历年卷/笔记，公开站点免登录）`search_zyxf` `browse_zyxf` `read_zyxf_file`。问复习资料、历年题先搜这里；搜不到才 `web_search`。资料是同学上传的共享件，转述要说明来源，别当官方标准答案。
 - 加餐券 `get_coupons`；设置 `get_app_settings` `set_app_setting` `check_update`
 - 闹钟 `set_alarm`、日历 `create_calendar_event`（交系统 App 确认）；登录诊断 `get_login_diagnostics`
 - 联网 `web_search` `web_fetch`；算术 `calculate`

--- a/app/src/main/java/com/xjtu/toolbox/agent/AgentRunner.kt
+++ b/app/src/main/java/com/xjtu/toolbox/agent/AgentRunner.kt
@@ -128,12 +128,23 @@ class AgentRunner(private val tools: AgentToolRegistry) {
                 addProperty("stream", true)
                 if (config.provider == AgentConfig.PROVIDER_DEEPSEEK) {
                     add("stream_options", JsonObject().apply { addProperty("include_usage", true) })
+                    // DeepSeek 新版思考参数族：档位是 none / low / high / max，
+                    // 而且 `reasoning_effort` **两处都能放**——顶层，或 `thinking` 对象里。
+                    // 官方示例两处都给，这里照做：中转服务商往往只认其中一处，
+                    // 只写一处就会出现"调了档但没生效"。
+                    //
+                    // 关思考走 `none`，不只是 `type=disabled`：新参数族里"不思考"是一个档位，
+                    // 只给 type 的旧写法在部分端点上被忽略。
+                    val effort = when {
+                        !config.thinkingEnabled -> "none"
+                        config.reasoningEffort != AgentConfig.REASONING_AUTO -> config.reasoningEffort
+                        else -> null
+                    }
                     add("thinking", JsonObject().apply {
                         addProperty("type", if (config.thinkingEnabled) "enabled" else "disabled")
+                        effort?.let { addProperty("reasoning_effort", it) }
                     })
-                    if (config.thinkingEnabled && config.reasoningEffort != AgentConfig.REASONING_AUTO) {
-                        addProperty("reasoning_effort", config.reasoningEffort)
-                    }
+                    effort?.let { addProperty("reasoning_effort", it) }
                 }
                 if (allowTools) {
                     add("tools", toolDefs)

--- a/app/src/main/java/com/xjtu/toolbox/agent/AgentScreen.kt
+++ b/app/src/main/java/com/xjtu/toolbox/agent/AgentScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Key
@@ -60,7 +61,14 @@ import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Stop
 import androidx.compose.runtime.*
 import androidx.compose.ui.graphics.Color
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.icons.filled.Image
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.graphics.asImageBitmap
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -690,19 +698,68 @@ private fun ChatPanel(
     var editingLast by rememberSaveable { mutableStateOf(false) }
     val keyboard = LocalSoftwareKeyboardController.current
 
+    // ── 图片附件 ──
+    //
+    // 只在模型认图片时给入口（见 AgentVision.supportsVision）。换模型会实时生效：
+    // 从视觉模型切到非视觉模型时，已经挑好的图要清掉，否则发出去必被服务端拒。
+    var attachments by remember { mutableStateOf<List<String>>(emptyList()) }
+    val attachScope = rememberCoroutineScope()
+    val visionEnabled = remember(config.provider, config.effectiveModel) {
+        AgentVision.supportsVision(config)
+    }
+    LaunchedEffect(visionEnabled) {
+        if (!visionEnabled && attachments.isNotEmpty()) attachments = emptyList()
+    }
+
+    val pickImages = rememberLauncherForActivityResult(
+        // PickMultipleVisualMedia 走系统相册选择器，**不需要读存储权限**——
+        // 用户在系统 UI 里挑哪张就授权哪张，比申请 READ_MEDIA_IMAGES 干净得多。
+        androidx.activity.result.contract.ActivityResultContracts.PickMultipleVisualMedia(
+            AgentVision.MAX_IMAGES_PER_MESSAGE
+        )
+    ) { uris ->
+        if (uris.isEmpty()) return@rememberLauncherForActivityResult
+        attachScope.launch {
+            val room = AgentVision.MAX_IMAGES_PER_MESSAGE - attachments.size
+            val added = withContext(Dispatchers.IO) {
+                uris.take(room).mapNotNull { AgentVision.attach(context, it) }
+            }
+            if (added.isEmpty()) {
+                Toast.makeText(context, "图片读取失败", Toast.LENGTH_SHORT).show()
+            } else {
+                attachments = attachments + added
+            }
+        }
+    }
+
     fun send() {
         val text = input.trim()
-        if (text.isBlank() || vm.contextExhausted) return
+        val images = attachments
+        if ((text.isBlank() && images.isEmpty()) || vm.contextExhausted) return
         // 没有 key 时点发送，直接把人送到配置页，而不是让消息石沉大海
         if (!config.isConfigured) { onOpenConfig(); return }
         input = ""
+        attachments = emptyList()
         keyboard?.hide()
         if (editingLast) {
             editingLast = false
             vm.replaceLastUserAndSend(text, config, loginState, context)
         } else {
-            vm.sendMessage(text, config, loginState, context)
+            vm.sendMessage(text, config, loginState, context, images = images)
         }
+    }
+
+    /**
+     * 卡片替用户发一句。
+     *
+     * 走的是和手打完全一样的路径（同一个 vm.sendMessage），所以历史、工具预算、限流
+     * 都照常；这条消息也会像用户自己打的那样出现在对话里，不会凭空多出一段回复。
+     */
+    fun askFromWidget(text: String) {
+        if (text.isBlank() || vm.isLoading || vm.contextExhausted) return
+        if (!config.isConfigured) { onOpenConfig(); return }
+        keyboard?.hide()
+        vm.sendMessage(text, config, loginState, context)
     }
 
     Column(
@@ -803,6 +860,7 @@ private fun ChatPanel(
                         showReasoning = config.showReasoning,
                         onNavigate = onNavigate,
                         toolEvents = row.tools,
+                        onAskFromWidget = ::askFromWidget,
                     )
                 }
             }
@@ -890,6 +948,21 @@ private fun ChatPanel(
             isLoading = vm.isLoading,
             contextExhausted = vm.contextExhausted,
             bottomReserve = bottomReserve,
+            attachments = attachments,
+            visionEnabled = visionEnabled,
+            onPickImage = {
+                pickImages.launch(
+                    androidx.activity.result.PickVisualMediaRequest(
+                        androidx.activity.result.contract.ActivityResultContracts
+                            .PickVisualMedia.ImageOnly
+                    )
+                )
+            },
+            onRemoveAttachment = { path ->
+                attachments = attachments - path
+                // 还没发出去就撤了，压缩件留着没用。
+                AgentVision.deleteAll(listOf(path))
+            },
         )
     }
 }
@@ -907,8 +980,15 @@ private fun AgentComposer(
     isLoading: Boolean,
     contextExhausted: Boolean,
     bottomReserve: Dp,
+    /** 待发送的图片路径。空列表表示这个模型不支持图片，连按钮都不显示。 */
+    attachments: List<String> = emptyList(),
+    /** 模型认不认图片。不认就不给入口——贴了也只会被服务端拒掉。 */
+    visionEnabled: Boolean = false,
+    onPickImage: () -> Unit = {},
+    onRemoveAttachment: (String) -> Unit = {},
 ) {
-    val canSend = input.isNotBlank() && !contextExhausted
+    // 只发图不打字是合理的（「这是什么」「帮我看看这张课表」）。
+    val canSend = (input.isNotBlank() || attachments.isNotEmpty()) && !contextExhausted
     val actionEnabled = isLoading || canSend
     var focused by remember { mutableStateOf(false) }
 
@@ -949,22 +1029,80 @@ private fun AgentComposer(
         WindowInsets.navigationBars.add(WindowInsets(bottom = bottomReserve))
     )
 
-    Box(
+    Column(
         Modifier
             .fillMaxWidth()
             .background(MiuixTheme.colorScheme.surface)
             .windowInsetsPadding(bottomInsets)
             .padding(horizontal = 12.dp, vertical = 8.dp),
     ) {
+        // 待发送的图片：贴在输入框上方，每张右上角一个叉。
+        if (attachments.isNotEmpty()) {
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState())
+                    .padding(start = 4.dp, end = 4.dp, bottom = 8.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                attachments.forEach { path ->
+                    Box {
+                        AttachmentThumb(path)
+                        Box(
+                            Modifier
+                                .align(Alignment.TopEnd)
+                                .padding(3.dp)
+                                .size(18.dp)
+                                .clip(CircleShape)
+                                .background(MiuixTheme.colorScheme.onSurface.copy(alpha = 0.55f))
+                                .clickable { onRemoveAttachment(path) },
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Icon(
+                                Icons.Default.Clear,
+                                contentDescription = "移除",
+                                tint = MiuixTheme.colorScheme.onPrimary,
+                                modifier = Modifier.size(11.dp),
+                            )
+                        }
+                    }
+                }
+            }
+        }
         Row(
             Modifier
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(24.dp))
                 .background(MiuixTheme.colorScheme.surfaceVariant)
                 .border(1.dp, borderColor, RoundedCornerShape(24.dp))
-                .padding(start = 16.dp, end = 6.dp, top = 6.dp, bottom = 6.dp),
+                .padding(start = 6.dp, end = 6.dp, top = 6.dp, bottom = 6.dp),
             verticalAlignment = Alignment.Bottom,
         ) {
+            if (visionEnabled) {
+                Box(
+                    Modifier
+                        .size(36.dp)
+                        .clip(CircleShape)
+                        .clickable(
+                            enabled = !contextExhausted &&
+                                attachments.size < AgentVision.MAX_IMAGES_PER_MESSAGE
+                        ) { onPickImage() },
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        Icons.Default.Image,
+                        contentDescription = "添加图片",
+                        tint = if (attachments.size < AgentVision.MAX_IMAGES_PER_MESSAGE) {
+                            MiuixTheme.colorScheme.onSurfaceVariantSummary
+                        } else {
+                            MiuixTheme.colorScheme.onSurface.copy(alpha = 0.25f)
+                        },
+                        modifier = Modifier.size(20.dp),
+                    )
+                }
+            } else {
+                Spacer(Modifier.width(10.dp))
+            }
             Box(
                 Modifier
                     .weight(1f)
@@ -1015,6 +1153,46 @@ private fun AgentComposer(
                     modifier = Modifier.size(18.dp),
                 )
             }
+        }
+    }
+}
+
+/**
+ * 本地图片缩略图。
+ *
+ * 自己 decode 而不是引第三方图片库：这些文件是 [AgentVision] 压过的，最长边 1300、
+ * 一二百 KB，数量上限 4 张，为它们拖进一整个加载框架不划算。
+ * `remember(path)` 保证同一张只解一次，重组不会反复读盘。
+ */
+@Composable
+private fun AttachmentThumb(path: String, size: Dp = 62.dp) {
+    val bitmap = remember(path) {
+        runCatching {
+            android.graphics.BitmapFactory.decodeFile(path)?.asImageBitmap()
+        }.getOrNull()
+    }
+    Box(
+        Modifier
+            .size(size)
+            .clip(RoundedCornerShape(10.dp))
+            .background(MiuixTheme.colorScheme.surfaceVariant),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (bitmap != null) {
+            androidx.compose.foundation.Image(
+                bitmap = bitmap,
+                contentDescription = "图片",
+                contentScale = androidx.compose.ui.layout.ContentScale.Crop,
+                modifier = Modifier.fillMaxSize(),
+            )
+        } else {
+            // 文件被清掉了（清缓存 / 换账号）。给个占位比留个空白格子清楚。
+            Icon(
+                Icons.Default.Image,
+                contentDescription = null,
+                tint = MiuixTheme.colorScheme.onSurfaceVariantSummary,
+                modifier = Modifier.size(20.dp),
+            )
         }
     }
 }
@@ -1237,6 +1415,8 @@ private fun MessageBubble(
     canEdit: Boolean = false,
     onEdit: () -> Unit = {},
     toolEvents: List<ChatMessage> = emptyList(),
+    /** 卡片替用户问一句（如资料卡上点"打开目录"）。 */
+    onAskFromWidget: (String) -> Unit = {},
 ) {
     // [LocalClipboard] 取代已废弃的 [LocalClipboardManager]：suspend setClip，跨进程兼容。
     val clipboard = androidx.compose.ui.platform.LocalClipboard.current
@@ -1255,24 +1435,35 @@ private fun MessageBubble(
     when (msg.role) {
         "user" -> {
             Column(Modifier.fillMaxWidth(), horizontalAlignment = Alignment.End) {
-                Surface(
-                    shape = RoundedCornerShape(20.dp, 6.dp, 20.dp, 20.dp),
-                    color = MiuixTheme.colorScheme.primary,
-                    modifier = Modifier
-                        .widthIn(max = 300.dp)
-                        .then(
-                            if (canEdit) Modifier.combinedClickable(
-                                onClick = {},
-                                onLongClick = onEdit,
-                            ) else Modifier
-                        ),
-                ) {
-                    Text(
-                        msg.content,
-                        modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp),
-                        style = MiuixTheme.textStyles.body1,
-                        color = MiuixTheme.colorScheme.onPrimary
-                    )
+                if (msg.images.isNotEmpty()) {
+                    Row(
+                        Modifier.padding(bottom = 6.dp),
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    ) {
+                        msg.images.forEach { AttachmentThumb(it, size = 76.dp) }
+                    }
+                }
+                // 只发图不打字时不画空气泡——一个空的蓝色圆角块看着像渲染坏了。
+                if (msg.content.isNotBlank()) {
+                    Surface(
+                        shape = RoundedCornerShape(20.dp, 6.dp, 20.dp, 20.dp),
+                        color = MiuixTheme.colorScheme.primary,
+                        modifier = Modifier
+                            .widthIn(max = 300.dp)
+                            .then(
+                                if (canEdit) Modifier.combinedClickable(
+                                    onClick = {},
+                                    onLongClick = onEdit,
+                                ) else Modifier
+                            ),
+                    ) {
+                        Text(
+                            msg.content,
+                            modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp),
+                            style = MiuixTheme.textStyles.body1,
+                            color = MiuixTheme.colorScheme.onPrimary
+                        )
+                    }
                 }
             }
         }
@@ -1308,6 +1499,9 @@ private fun MessageBubble(
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(top = if (msg.content.isNotBlank()) 10.dp else 0.dp),
+                        // 卡片上点"打开目录"等于替用户问一句，直接走正常发送路径，
+                        // 历史、限流、工具预算全都照常。
+                        onAsk = onAskFromWidget,
                     )
                 }
                 if (msg.navSuggestions.isNotEmpty()) {
@@ -1531,6 +1725,7 @@ private fun ConfigPanel(
                 "faculty" to "教师主页",
                 "memory" to "记住我的偏好",
                 "library" to "图书馆",
+                "zyxf" to "仲英学辅资料站",
                 "lms" to "思源学堂",
                 "fitness" to "体测查询",
                 "textbook" to "教材",
@@ -1703,11 +1898,12 @@ private fun ConfigPanel(
                             OverlaySpinnerPreference(
                                 title = "思考强度",
                                 summary = when (reasoningEffort) {
-                                    AgentConfig.REASONING_HIGH -> "高"
-                                    AgentConfig.REASONING_MAX -> "最大"
-                                    else -> "自动（Agent 请求通常使用最大）"
+                                    AgentConfig.REASONING_AUTO -> "自动（由服务端按模型默认档）"
+                                    else -> AgentConfig.reasoningEffortLabel(reasoningEffort)
                                 },
-                                items = listOf("自动", "高", "最大").map { DropdownItem(text = it) },
+                                // 选项文案从 efforts 现推，别再手写一份平行列表——
+                                // 两边靠下标对齐，档位一多就会错位成"选高得到最大"。
+                                items = efforts.map { DropdownItem(text = AgentConfig.reasoningEffortLabel(it)) },
                                 selectedIndex = efforts.indexOf(reasoningEffort).coerceAtLeast(0),
                                 onSelectedIndexChange = {
                                     reasoningEffort = efforts[it]

--- a/app/src/main/java/com/xjtu/toolbox/agent/AgentSessionStore.kt
+++ b/app/src/main/java/com/xjtu/toolbox/agent/AgentSessionStore.kt
@@ -33,6 +33,8 @@ data class StoredMessage(
     val reasoningContent: String? = null,
     val timestamp: Long? = null,
     val toolError: String? = null,
+    /** 图片附件的本地路径。老会话没有这个字段，反序列化得到 null。 */
+    val images: List<String>? = null,
 )
 
 /** 一个会话的完整内容：UI 消息 + 供续聊的 LLM 历史（JsonArray 的字符串形式）。 */

--- a/app/src/main/java/com/xjtu/toolbox/agent/AgentTool.kt
+++ b/app/src/main/java/com/xjtu/toolbox/agent/AgentTool.kt
@@ -85,6 +85,9 @@ class AgentToolRegistry(
         "web_fetch" to "web",
         "get_library_booking" to "library",
         "get_library_seats" to "library",
+        "search_zyxf" to "zyxf",
+        "browse_zyxf" to "zyxf",
+        "read_zyxf_file" to "zyxf",
         "get_textbooks" to "textbook",
         "get_coupons" to "coupon",
         "get_lms_courses" to "lms",
@@ -415,6 +418,21 @@ class AgentToolRegistry(
         arr.add(tool("get_library_seats",
             "查询图书馆某区域的空闲座位数。需要图书馆系统登录。area 传区域名（模糊匹配，如「北楼二层外文库」），不填则列出所有可选区域名称。",
             params("area" to strProp("区域名称，不填返回区域列表。"))))
+        arr.add(tool("search_zyxf",
+            "检索仲英学辅资料站（zyxf.top）的公开共享资料：课件、历年卷、笔记、习题解答等，按文件名和目录名模糊匹配。无需登录。用于「有没有XX的复习资料/历年题」这类问题。",
+            params(
+                "keyword" to strProp("检索关键词，如「高等数学 历年」「大物 期中」。建议用课程名，别太长。")
+            )))
+        arr.add(tool("browse_zyxf",
+            "浏览仲英学辅资料站的目录。folder_id 不填或填 0 列出根目录（即全部课程/分类），填 search_zyxf 或本工具返回的目录 ID 进入下一级。无需登录。不知道该搜什么词时先用它看看有哪些课程。",
+            params(
+                "folder_id" to intProp("目录 ID；不填或 0 表示根目录。")
+            )))
+        arr.add(tool("read_zyxf_file",
+            "读取仲英学辅资料站的一份资料。file_id 来自 search_zyxf / browse_zyxf。纯文本（txt/csv/md 等）直接返回正文；PDF、Word、PPT 等只返回下载直链与大小，不解析内容。",
+            params(
+                "file_id" to intProp("文件 ID。")
+            )))
         arr.add(tool("get_textbooks",
             "查询日程/课表里的本人教材信息，来自教务系统教材报表，可按课程名筛选。需要教务系统登录；成功后会写入缓存。",
             params(
@@ -595,6 +613,9 @@ class AgentToolRegistry(
                 location = args["location"] as? String,
                 description = args["description"] as? String
             )
+            "search_zyxf" -> searchZyxf(args["keyword"] as? String ?: "")
+            "browse_zyxf" -> browseZyxf((args["folder_id"] as? Double)?.toInt() ?: 0)
+            "read_zyxf_file" -> readZyxfFile((args["file_id"] as? Double)?.toInt() ?: 0)
             "get_library_booking" -> getLibraryBooking()
             "get_library_seats" -> getLibrarySeats(args["area"] as? String)
             "get_textbooks" -> getTextbooks(args["course"] as? String, args["term"] as? String)
@@ -744,7 +765,7 @@ class AgentToolRegistry(
             val startDate = startStr?.let { s -> runCatching { LocalDate.parse(s) }.getOrNull() }
             startDate?.let { sd ->
                 val daysSince = java.time.temporal.ChronoUnit.DAYS.between(sd, today).toInt()
-                val w = (daysSince / 7) + 1
+                val w = com.xjtu.toolbox.schedule.TermWeeks.weekOf(sd, today)
                 // 含起始日与已过天数，便于推算"整学期"区间（如校园卡整学期账单天数）
                 if (w in 1..25) "第${w}周（起始 $startStr，开学至今 $daysSince 天）" else null
             }
@@ -1022,7 +1043,7 @@ class AgentToolRegistry(
 
         if (dateStr != null) {
             val targetDate = runCatching { LocalDate.parse(dateStr) }.getOrElse { LocalDate.now() }
-            val weekNum = ((java.time.temporal.ChronoUnit.DAYS.between(startDate, targetDate) / 7) + 1).toInt()
+            val weekNum = com.xjtu.toolbox.schedule.TermWeeks.weekOf(startDate, targetDate)
             val dayCourses = courses.filter { it.dayOfWeek == targetDate.dayOfWeek.value && it.isInWeek(weekNum) }
                 .sortedBy { it.startSection }
             if (dayCourses.isEmpty()) return "${targetDate}（第${weekNum}周 ${dayNames[targetDate.dayOfWeek.value]}）没有课。"
@@ -1035,7 +1056,7 @@ class AgentToolRegistry(
             }
         } else {
             val today = LocalDate.now()
-            val weekNum = ((java.time.temporal.ChronoUnit.DAYS.between(startDate, today) / 7) + 1).toInt()
+            val weekNum = com.xjtu.toolbox.schedule.TermWeeks.weekOf(startDate, today)
             if (weekNum <= 0) return "当前不在学期内。"
             val weekCourses = courses.filter { it.isInWeek(weekNum) }
                 .sortedWith(compareBy({ it.dayOfWeek }, { it.startSection }))
@@ -1624,21 +1645,140 @@ class AgentToolRegistry(
         }
     }
 
+    // ── 仲英学辅资料站 ────────────────────────────────────────────────────
+    //
+    // 资料站是**公开站点**，不带任何校内凭据，所以这三个工具不走 ensureSite。
+    // 返回里一律带上 ID，模型才接得下去：search → read，或 browse → browse → read。
+
+    /** 一行条目的统一写法，目录和文件在同一份列表里要能一眼分清。 */
+    private fun zyxfLine(e: com.xjtu.toolbox.zyxf.ZyxfApi.Entry): String = buildString {
+        if (e.isFolder) {
+            append("📁 ${e.name}（目录 ID ${e.id}）")
+        } else {
+            append("📄 ${e.name}（文件 ID ${e.id}")
+            e.sizeText.takeIf { it.isNotBlank() }?.let { append("，$it") }
+            if (!e.readable) append("，不可直接阅读")
+            append("）")
+        }
+        e.path.takeIf { it.isNotBlank() }?.let { append("  ← $it") }
+    }
+
+    /** 把条目转成卡片。只带 UI 要用的字段，卡片得随会话一起存盘。 */
+    private fun zyxfWidgetOf(
+        query: String,
+        entries: List<com.xjtu.toolbox.zyxf.ZyxfApi.Entry>,
+    ) = ZyxfWidget(
+        query = query,
+        items = entries.take(20).map {
+            ZyxfEntryRef(
+                id = it.id,
+                name = it.name,
+                path = it.path,
+                sizeText = it.sizeText,
+                isFolder = it.isFolder,
+            )
+        },
+    )
+
+    private suspend fun searchZyxf(keyword: String): String = withContext(Dispatchers.IO) {
+        if (keyword.isBlank()) return@withContext "请给出检索关键词，比如课程名。"
+        try {
+            val r = com.xjtu.toolbox.zyxf.ZyxfApi.search(keyword)
+            if (r.entries.isEmpty()) {
+                return@withContext "仲英学辅资料站没有匹配「$keyword」的资料。换个更短的关键词（比如只留课程名），或用 browse_zyxf 看看有哪些分类。"
+            }
+            pendingWidgets.add(zyxfWidgetOf(keyword, r.entries))
+            buildString {
+                append("仲英学辅资料站「$keyword」检索结果（共 ${r.entries.size} 条")
+                if (r.truncated) append("，服务端已截断，关键词再具体些能看到更多")
+                append("）：\n")
+                r.entries.take(25).forEach { append("• ${zyxfLine(it)}\n") }
+                // 卡片已经把「下载」做成一次点击了，别再让模型复述文件名劝用户去哪儿下。
+                append("\n以上已在卡片中列出，用户点文件即可下载，无需你再给链接或复述文件名。")
+                append("要看正文用 read_zyxf_file(file_id)，进目录用 browse_zyxf(folder_id)。")
+            }.trimEnd()
+        } catch (e: Exception) {
+            "检索仲英学辅资料站失败：${e.message?.take(60) ?: "网络异常"}"
+        }
+    }
+
+    private suspend fun browseZyxf(folderId: Int): String = withContext(Dispatchers.IO) {
+        try {
+            val entries = com.xjtu.toolbox.zyxf.ZyxfApi.listFolder(folderId.coerceAtLeast(0))
+            val where = if (folderId <= 0) "根目录"
+                else com.xjtu.toolbox.zyxf.ZyxfApi.breadcrumb(folderId).ifBlank { "目录 $folderId" }
+            if (entries.isEmpty()) return@withContext "仲英学辅资料站 $where 是空的。"
+            pendingWidgets.add(zyxfWidgetOf(where, entries))
+            buildString {
+                append("仲英学辅资料站 · $where（${entries.size} 项）：\n")
+                entries.take(40).forEach { append("• ${zyxfLine(it)}\n") }
+                if (entries.size > 40) append("…（还有 ${entries.size - 40} 项）\n")
+                append("\n以上已在卡片中列出，用户点文件即可下载。")
+            }.trimEnd()
+        } catch (e: Exception) {
+            "浏览仲英学辅资料站失败：${e.message?.take(60) ?: "网络异常"}"
+        }
+    }
+
+    private suspend fun readZyxfFile(fileId: Int): String = withContext(Dispatchers.IO) {
+        if (fileId <= 0) return@withContext "请提供 file_id，可先用 search_zyxf 或 browse_zyxf 查到。"
+        try {
+            val link = com.xjtu.toolbox.zyxf.ZyxfApi.fileLink(fileId)
+            val ext = link.ext.lowercase().removePrefix(".")
+            val entry = com.xjtu.toolbox.zyxf.ZyxfApi.Entry(
+                id = fileId, name = link.name, isFolder = false,
+                sizeBytes = link.sizeBytes, ext = ext,
+            )
+            // 二进制文档不在 App 里解析：PDF/Office 的文本抽取要拖进一整套解析库，
+            // 而资料站服务端本来就有 WebOffice 预览。这里给链接，让用户去看。
+            if (!entry.readable) {
+                return@withContext buildString {
+                    append("「${link.name}」是 ${ext.uppercase().ifBlank { "二进制" }} 文件")
+                    entry.sizeText.takeIf { it.isNotBlank() }?.let { append("（$it）") }
+                    append("，屁岱不解析它的内容。")
+                    append("可以在资料站页面预览或下载：${link.url}")
+                    append("\n（该直链约 30 分钟后失效。）")
+                }
+            }
+            val text = com.xjtu.toolbox.zyxf.ZyxfApi.readText(entry)
+                ?: return@withContext "读取「${link.name}」失败，稍后再试。"
+            buildString {
+                append("「${link.name}」内容：\n")
+                append(text.take(4000))
+                if (text.length > 4000) append("\n…（已截断，只给了开头 4000 字）")
+            }
+        } catch (e: Exception) {
+            "读取仲英学辅资料失败：${e.message?.take(60) ?: "网络异常"}"
+        }
+    }
+
     private suspend fun getLibrarySeats(area: String?): String {
         val site = ensureSite(LoginType.LIBRARY)
             ?: return loginHint(LoginType.LIBRARY)
-        val areaMap = com.xjtu.toolbox.library.LibraryApi.AREA_MAP
+        val api = com.xjtu.toolbox.library.LibraryApi(site)
+        // 区域按校区各不相同，不能拿兴庆那张写死的表当全集——雁塔/创新港的同学问
+        // 「哪个区有空位」，会被告知一串他们根本去不了的兴庆区域（issue #42）。
+        // 这里按账号当前校区逐层现拉；拉不到（网络异常）才退回兴庆表。
+        val campus = runCatching { api.getCurrentCampus() }.getOrNull()
+            ?: com.xjtu.toolbox.library.LibraryCampus.DEFAULT
+        val discovered = linkedMapOf<String, String>()   // 中文名 → 区域码
+        campus.floorCodes.forEach { floorCode ->
+            runCatching { api.getFloorAreas(floorCode) }.getOrNull()
+                ?.forEach { (code, name) -> discovered[name] = code }
+        }
+        val areaMap = discovered.ifEmpty { com.xjtu.toolbox.library.LibraryApi.AREA_MAP }
+        val where = "${campus.displayName}校区"
         if (area.isNullOrBlank()) {
-            return "可查询的图书馆区域：\n" + areaMap.keys.joinToString("、")
+            return "$where 可查询的图书馆区域：\n" + areaMap.keys.joinToString("、")
         }
         val entry = areaMap.entries.firstOrNull {
             it.key == area || it.key.contains(area) || area.contains(it.key)
-        } ?: return "未找到区域「$area」。可选：${areaMap.keys.joinToString("、")}"
+        } ?: return "$where 未找到区域「$area」。可选：${areaMap.keys.joinToString("、")}"
         return try {
-            when (val r = com.xjtu.toolbox.library.LibraryApi(site).getSeats(entry.value)) {
+            when (val r = api.getSeats(entry.value)) {
                 is com.xjtu.toolbox.library.SeatResult.Success -> {
                     val free = r.seats.count { it.available }
-                    "${entry.key}：空闲 $free / 共 ${r.seats.size} 座"
+                    "$where ${entry.key}：空闲 $free / 共 ${r.seats.size} 座"
                 }
                 is com.xjtu.toolbox.library.SeatResult.AuthError ->
                     "图书馆登录失效，请重新进入图书馆页面。"

--- a/app/src/main/java/com/xjtu/toolbox/agent/AgentViewModel.kt
+++ b/app/src/main/java/com/xjtu/toolbox/agent/AgentViewModel.kt
@@ -29,6 +29,8 @@ data class ChatMessage(
     val navSuggestions: List<Pair<String, String>> = emptyList(),
     val widgets: List<AgentWidget> = emptyList(),
     val reasoningContent: String = "",
+    /** 随这条消息发出的图片，存的是应用私有目录里的压缩件路径。见 [AgentVision]。 */
+    val images: List<String> = emptyList(),
     val timestamp: Long = System.currentTimeMillis(),
     /**
      * 工具调用失败信息：非 null 时 UI 上对应气泡标红并显示原因。
@@ -97,10 +99,13 @@ class AgentViewModel : ViewModel() {
     ) {
         val text = newText.trim()
         if (text.isBlank()) return
+        // 改的是文字，图片跟着这条消息一起重发：用户点"改上一条"是想换个问法，
+        // 不是想把图撤回——丢掉图会让新问题突然没了上下文。
+        val keptImages = messages.lastOrNull { it.role == "user" }?.images.orEmpty()
         currentJob?.cancel()
         isLoading = false
         dropLastUserTurn()
-        sendMessage(text, config, loginState, context)
+        sendMessage(text, config, loginState, context, images = keptImages)
     }
 
     private fun dropLastUserTurn() {
@@ -198,6 +203,9 @@ class AgentViewModel : ViewModel() {
                 navSuggestions = m.nav.mapNotNull { if (it.size >= 2) it[0] to it[1] else null },
                 widgets = m.widgets.orEmpty().mapNotNull { storedToWidget(it, gson) },
                 reasoningContent = m.reasoningContent.orEmpty(),
+                // 图片文件可能已被清掉（清缓存、换账号），这里只过滤掉不存在的，
+                // 气泡少显示一张图，比留个破图标好。
+                images = m.images.orEmpty().filter { path -> java.io.File(path).isFile },
                 timestamp = m.timestamp ?: System.currentTimeMillis(),
                 isToolCall = false,
                 toolError = m.toolError,
@@ -246,6 +254,7 @@ class AgentViewModel : ViewModel() {
                 it.reasoningContent.takeIf { reasoning -> reasoning.isNotBlank() },
                 it.timestamp,
                 it.toolError,
+                it.images.takeIf { images -> images.isNotEmpty() },
             )
         }
         val title = if (store.isLocked(id))
@@ -301,15 +310,18 @@ class AgentViewModel : ViewModel() {
         context: Context,
         /** 不进聊天气泡，只进发给模型的 user 消息。见屁岱提醒快照。 */
         llmAnnex: String? = null,
+        /** 随消息发送的图片路径，见 [AgentVision.attach]。 */
+        images: List<String> = emptyList(),
     ) {
-        if (userText.isBlank() || isLoading) return
+        // 只发图不打字是合理的（「这是什么」），所以有图时允许正文为空。
+        if ((userText.isBlank() && images.isEmpty()) || isLoading) return
         if (contextExhausted) {
             errorMessage = CONTEXT_EXHAUSTED_MESSAGE
             return
         }
         if (currentSessionId == null) newSession()
         errorMessage = null
-        messages.add(ChatMessage("user", userText))
+        messages.add(ChatMessage("user", userText, images = images))
         isLoading = true
 
         val turnSid = currentSessionId   // 本轮所属会话；切走后不再写当前 messages，避免串台
@@ -334,8 +346,13 @@ class AgentViewModel : ViewModel() {
                 val runner = AgentRunner(registry)
                 // 偏好也要进签名：模型刚 remember 了一条，下一轮系统提示就得带上它，
                 // 否则要等到改名字或跨天才生效——表现就是"说记住了，但下一句就忘了"。
+                // 模型与接入方式也要进签名：system prompt 里写着「`<模型 ID>`……禁止自称其他模型」，
+                // 签名不带它，换完模型这句还是旧的，屁岱会一口咬定自己是上一个模型。
+                // 思考强度**不**进签名——它不进 system prompt，改档不该把历史前缀推倒重来
+                // （那才是真丢缓存）。
                 val currentPromptSignature =
                     "${config.effectiveName}|${config.responseStyle}|${config.maxToolCalls}|" +
+                        "${config.effectiveModel}|${config.provider}|" +
                         "${LocalDate.now()}|${registry.memoryBlock().hashCode()}"
                 if (promptSignature != null && promptSignature != currentPromptSignature) {
                     val kept = (0 until llmHistory.size())
@@ -377,13 +394,17 @@ class AgentViewModel : ViewModel() {
                         append(llmAnnex.trim())
                         append("\n\n")
                     }
-                    append(userText)
+                    append(userText.ifBlank { "（见图）" })
                 }
                 llmHistory.add(JsonObject().apply {
                     addProperty("role", "user")
-                    addProperty("content", llmUser)
+                    // 无图时这里仍是纯字符串，历史结构和以前完全一致。
+                    add("content", AgentVision.userContent(llmUser, images))
                 })
                 sanitizeHistory()   // 自愈：清掉上一次中断留下的 tool_calls 残体
+                // 只留最近两轮的图：整段历史每轮都要重发一遍，不裁剪的话
+                // 贴过图的长对话会一直在重传同几张图。
+                AgentVision.pruneOldImages(llmHistory)
 
                 val calledTools = mutableListOf<String>()
 

--- a/app/src/main/java/com/xjtu/toolbox/agent/AgentVision.kt
+++ b/app/src/main/java/com/xjtu/toolbox/agent/AgentVision.kt
@@ -1,0 +1,187 @@
+package com.xjtu.toolbox.agent
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.ImageDecoder
+import android.net.Uri
+import android.util.Base64
+import android.util.Log
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import java.io.File
+import java.util.UUID
+
+/**
+ * 屁岱的图片输入。
+ *
+ * 走 OpenAI 兼容的 `content` 数组（`{"type":"image_url","image_url":{"url":"data:…;base64,…"}}`），
+ * DeepSeek、OpenAI、以及绝大多数中转都是这一套。
+ *
+ * ### 为什么要在本地先压
+ * 手机相册随手一张就是 4000×3000、5 MB 起步，而服务端拿到图后自己会缩到约 1300×1300
+ * （每张图最多约 1024 token）——原图那几兆流量纯属白烧，在校园网上还容易直接超时。
+ * 所以这里统一缩到 [MAX_EDGE] 并转成 JPEG 再编码。
+ *
+ * ### 为什么落盘而不是只留 content://
+ * 相册给的 `content://` URI 是**临时授权**，进程重启、甚至用户在相册里删掉原图之后就读不到了，
+ * 而会话是要存盘、下次还能翻回来的。所以选中即拷一份压缩件到应用私有目录，
+ * 消息里存的是这份拷贝的路径。
+ */
+object AgentVision {
+
+    private const val TAG = "AgentVision"
+
+    /** 压缩后最长边。对齐服务端的重采样尺寸，再大不会提高识别效果，只会更慢。 */
+    private const val MAX_EDGE = 1300
+
+    private const val JPEG_QUALITY = 88
+
+    /** 单条消息最多带几张。多了既费 token 也让模型抓不住重点。 */
+    const val MAX_IMAGES_PER_MESSAGE = 4
+
+    /**
+     * 历史里保留图片的**用户轮数**。
+     *
+     * 图片是按 token 计费的，而且每轮请求都会把整段历史重发一遍。不裁剪的话，
+     * 一段聊了十轮、贴过五张图的对话，每问一句都要重传五张图。
+     * 更早的图在正文里留一句占位说明，模型知道"这里曾经有图"就够了。
+     */
+    private const val KEEP_IMAGE_TURNS = 2
+
+    private const val DIR_NAME = "agent_images"
+
+    /**
+     * 这个模型认不认图片。
+     *
+     * 按模型 ID 猜，不额外发探测请求：猜错的代价是按钮多显示/少显示一个，
+     * 而为每次换模型多打一轮网络请求，代价更大。
+     * - DeepSeek：`deepseek-flash` 支持（`deepseek-v4-pro` 官方未列为视觉模型）。
+     * - OpenAI：4o 及之后的主线模型都支持，`*-audio`、`*-realtime` 这些除外。
+     * - 自定义端点：无从判断，一律放行——用户自己填的中转，他比我们清楚。
+     */
+    fun supportsVision(config: AgentConfig): Boolean {
+        val model = config.effectiveModel.lowercase()
+        return when (config.provider) {
+            AgentConfig.PROVIDER_DEEPSEEK -> "flash" in model
+            AgentConfig.PROVIDER_OPENAI ->
+                ("gpt-4o" in model || "gpt-4.1" in model || "gpt-5" in model || "o3" in model || "o4" in model) &&
+                    "audio" !in model && "realtime" !in model
+            else -> true
+        }
+    }
+
+    private fun dir(context: Context): File =
+        File(context.filesDir, "$DIR_NAME${com.xjtu.toolbox.account.AccountContext.safeSuffix()}")
+            .apply { mkdirs() }
+
+    /**
+     * 把用户选中的图片压好存进私有目录，返回文件绝对路径；失败返回 null。
+     *
+     * 必须在 IO 线程调用。
+     */
+    fun attach(context: Context, uri: Uri): String? = try {
+        val source = decodeScaled(context, uri)
+        if (source == null) {
+            null
+        } else {
+            val out = File(dir(context), "${UUID.randomUUID()}.jpg")
+            out.outputStream().use { source.compress(Bitmap.CompressFormat.JPEG, JPEG_QUALITY, it) }
+            source.recycle()
+            out.absolutePath
+        }
+    } catch (e: Exception) {
+        Log.w(TAG, "attach failed: $uri", e)
+        null
+    }
+
+    /**
+     * 按 [MAX_EDGE] 解码。
+     *
+     * 用 [ImageDecoder] 而不是 BitmapFactory：
+     * - `setTargetSize` 在**解码阶段**就采样，不会先把 5000 万像素整张读进内存再缩
+     *   （那一步就能 OOM）；
+     * - 它会自己按 EXIF 摆正方向。竖着拍的照片在文件里常常是横着存的，不转的话
+     *   模型看到的是躺倒的课表——它不会提醒你图歪了，只会答错。
+     *
+     * `ALLOCATOR_SOFTWARE` 是必须的：默认可能给出 HARDWARE bitmap，那种读不到像素，
+     * [Bitmap.compress] 会失败。
+     */
+    private fun decodeScaled(context: Context, uri: Uri): Bitmap? = runCatching {
+        val source = ImageDecoder.createSource(context.contentResolver, uri)
+        ImageDecoder.decodeBitmap(source) { decoder, info, _ ->
+            decoder.allocator = ImageDecoder.ALLOCATOR_SOFTWARE
+            decoder.isMutableRequired = false
+            val longEdge = maxOf(info.size.width, info.size.height)
+            if (longEdge > MAX_EDGE) {
+                val scale = MAX_EDGE.toFloat() / longEdge
+                decoder.setTargetSize(
+                    (info.size.width * scale).toInt().coerceAtLeast(1),
+                    (info.size.height * scale).toInt().coerceAtLeast(1),
+                )
+            }
+        }
+    }.onFailure { Log.w(TAG, "decode failed: $uri", it) }.getOrNull()
+
+    /** 读成 `data:image/jpeg;base64,…`。文件不存在返回 null。 */
+    fun dataUri(path: String): String? = runCatching {
+        val f = File(path)
+        if (!f.isFile) return null
+        "data:image/jpeg;base64," + Base64.encodeToString(f.readBytes(), Base64.NO_WRAP)
+    }.getOrNull()
+
+    /** 删掉这些附件文件。会话被删时调用，别让压缩件在私有目录里越堆越多。 */
+    fun deleteAll(paths: List<String>) {
+        paths.forEach { runCatching { File(it).delete() } }
+    }
+
+    /**
+     * 组装一条带图的 user 消息内容。
+     *
+     * 没有可用图片时返回**纯字符串**而不是单元素数组：纯文本对话的历史结构不该因为
+     * "这个版本支持图片了"而整体改变形状，那会让所有旧会话的前缀缓存一次性失效。
+     */
+    fun userContent(text: String, imagePaths: List<String>): com.google.gson.JsonElement {
+        val uris = imagePaths.mapNotNull { dataUri(it) }
+        if (uris.isEmpty()) return com.google.gson.JsonPrimitive(text)
+        return JsonArray().apply {
+            add(JsonObject().apply {
+                addProperty("type", "text")
+                addProperty("text", text)
+            })
+            uris.forEach { uri ->
+                add(JsonObject().apply {
+                    addProperty("type", "image_url")
+                    add("image_url", JsonObject().apply { addProperty("url", uri) })
+                })
+            }
+        }
+    }
+
+    /**
+     * 把过老的图片从历史里摘掉，只留最近 [KEEP_IMAGE_TURNS] 轮。
+     *
+     * 就地改写传入的数组。被摘掉的那条 user 消息退回纯文本，并在末尾补一句说明，
+     * 免得模型对着"用户明明发过图"的空气找图。
+     */
+    fun pruneOldImages(messages: JsonArray) {
+        val imageTurns = (0 until messages.size())
+            .filter { i ->
+                val m = messages[i] as? JsonObject ?: return@filter false
+                m.get("role")?.asString == "user" && m.get("content")?.isJsonArray == true
+            }
+        if (imageTurns.size <= KEEP_IMAGE_TURNS) return
+
+        imageTurns.dropLast(KEEP_IMAGE_TURNS).forEach { i ->
+            val m = messages[i].asJsonObject
+            val parts = m.getAsJsonArray("content")
+            val text = (0 until parts.size())
+                .mapNotNull { (parts[it] as? JsonObject) }
+                .filter { it.get("type")?.asString == "text" }
+                .joinToString("\n") { it.get("text")?.asString.orEmpty() }
+            val count = (0 until parts.size())
+                .count { (parts[it] as? JsonObject)?.get("type")?.asString == "image_url" }
+            m.remove("content")
+            m.addProperty("content", "$text\n（此前随这条消息发送的 $count 张图片已从上下文中移除，如需再看请重新发送。）")
+        }
+    }
+}

--- a/app/src/main/java/com/xjtu/toolbox/agent/AgentWidget.kt
+++ b/app/src/main/java/com/xjtu/toolbox/agent/AgentWidget.kt
@@ -1,12 +1,14 @@
 package com.xjtu.toolbox.agent
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -24,6 +26,9 @@ import top.yukonga.miuix.kmp.basic.CardDefaults
 import top.yukonga.miuix.kmp.basic.HorizontalDivider
 import top.yukonga.miuix.kmp.basic.Surface
 import top.yukonga.miuix.kmp.basic.Text
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import top.yukonga.miuix.kmp.theme.MiuixTheme
 
 /**
@@ -52,6 +57,24 @@ data class GradeWidget(val grades: List<ReportedGrade>, val gpa: Double?, val to
 /** 校园卡信息。 */
 data class CardWidget(val info: CardInfo) : AgentWidget
 
+/**
+ * 仲英学辅资料站的检索结果。
+ *
+ * 和其它卡片不同，这张是**可操作**的：点文件就下载，点目录就让屁岱继续往里翻。
+ * 检索结果天然是"给你一串候选，你挑一个"，纯文本把文件名和 ID 抄一遍再让用户
+ * 复述给屁岱，中间那几步毫无意义。
+ */
+data class ZyxfWidget(val query: String, val items: List<ZyxfEntryRef>) : AgentWidget
+
+/** 卡片里的一条。字段全是可序列化的原始类型，卡片要随会话一起存盘。 */
+data class ZyxfEntryRef(
+    val id: Int,
+    val name: String,
+    val path: String,
+    val sizeText: String,
+    val isFolder: Boolean,
+)
+
 fun AgentWidget.toStored(gson: Gson): StoredWidget =
     StoredWidget(javaClass.simpleName, gson.toJson(this))
 
@@ -63,6 +86,7 @@ fun storedToWidget(stored: StoredWidget, gson: Gson): AgentWidget? = runCatching
         "AttendanceWidget" -> gson.fromJson(stored.json, AttendanceWidget::class.java)
         "GradeWidget" -> gson.fromJson(stored.json, GradeWidget::class.java)
         "CardWidget" -> gson.fromJson(stored.json, CardWidget::class.java)
+        "ZyxfWidget" -> gson.fromJson(stored.json, ZyxfWidget::class.java)
         else -> null
     }
 }.getOrNull()
@@ -71,8 +95,16 @@ private val DAY_NAMES = listOf("", "周一", "周二", "周三", "周四", "周�
 
 // ── 渲染入口 ─────────────────────────────────────────────────────────────
 
+/**
+ * @param onAsk 卡片想替用户问屁岱一句（比如点目录 → "打开目录 12"）。
+ *              默认丢弃：历史消息重绘时没有可用的输入通道。
+ */
 @Composable
-fun AgentWidgetView(widget: AgentWidget, modifier: Modifier = Modifier) {
+fun AgentWidgetView(
+    widget: AgentWidget,
+    modifier: Modifier = Modifier,
+    onAsk: (String) -> Unit = {},
+) {
     when (widget) {
         is ScheduleWidget   -> ScheduleWidgetView(widget, modifier)
         is ExamWidget       -> ExamWidgetView(widget, modifier)
@@ -80,6 +112,7 @@ fun AgentWidgetView(widget: AgentWidget, modifier: Modifier = Modifier) {
         is AttendanceWidget -> AttendanceWidgetView(widget, modifier)
         is GradeWidget      -> GradeWidgetView(widget, modifier)
         is CardWidget       -> CardWidgetView(widget, modifier)
+        is ZyxfWidget       -> ZyxfWidgetView(widget, modifier, onAsk)
     }
 }
 
@@ -316,6 +349,111 @@ private fun CardWidgetView(w: CardWidget, modifier: Modifier) {
             Spacer(Modifier.height(2.dp))
             Text(flags.joinToString(" · "), style = MiuixTheme.textStyles.footnote1,
                 color = MiuixTheme.colorScheme.error, fontWeight = FontWeight.Bold)
+        }
+    }
+}
+
+
+// ── 仲英学辅资料卡 ───────────────────────────────────────────────────────
+
+private const val ZYXF_DOWNLOADING = "下载中…"
+
+/**
+ * 资料检索结果卡。
+ *
+ * 下载直接在卡片里做，不经过屁岱再转一轮：模型手上没有 Context，也不该由它替用户
+ * 决定"要不要往手机里写文件"。点一下就开始下，结果标在这一行上。
+ * 点目录则把"继续翻这一层"交回给屁岱（[onAsk]），因为那本来就是它该接着做的事。
+ */
+@Composable
+private fun ZyxfWidgetView(w: ZyxfWidget, modifier: Modifier, onAsk: (String) -> Unit) {
+    val context = androidx.compose.ui.platform.LocalContext.current
+    val scope = androidx.compose.runtime.rememberCoroutineScope()
+    // 每行的下载状态，key 是文件 ID；滚动离屏再回来也不会丢。
+    val states = androidx.compose.runtime.remember {
+        androidx.compose.runtime.mutableStateMapOf<Int, String>()
+    }
+    val shown = w.items.take(12)
+
+    WidgetCard(
+        title = "仲英学辅资料",
+        accent = MiuixTheme.colorScheme.primary,
+        subtitle = w.query.takeIf { it.isNotBlank() },
+        modifier = modifier,
+    ) {
+        shown.forEach { item ->
+            val state = states[item.id]
+            val busy = state == ZYXF_DOWNLOADING
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(8.dp))
+                    .clickable(enabled = !busy) {
+                        if (item.isFolder) {
+                            onAsk("打开仲英学辅资料站的目录 ${item.id}（${item.name}）")
+                        } else {
+                            states[item.id] = ZYXF_DOWNLOADING
+                            scope.launch {
+                                val saved = withContext(Dispatchers.IO) {
+                                    runCatching {
+                                        com.xjtu.toolbox.zyxf.ZyxfApi.download(context, item.id)
+                                    }.getOrNull()
+                                }
+                                states[item.id] = if (saved != null) "已保存到下载" else "下载失败，稍后再试"
+                            }
+                        }
+                    }
+                    .padding(horizontal = 2.dp, vertical = 5.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    if (item.isFolder) "📁" else "📄",
+                    style = MiuixTheme.textStyles.footnote1,
+                )
+                Spacer(Modifier.width(8.dp))
+                Column(Modifier.weight(1f)) {
+                    Text(
+                        item.name,
+                        style = MiuixTheme.textStyles.body2,
+                        fontWeight = FontWeight.Medium,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    val sub = listOfNotNull(
+                        item.path.takeIf { it.isNotBlank() },
+                        item.sizeText.takeIf { it.isNotBlank() },
+                        state,
+                    ).joinToString(" · ")
+                    if (sub.isNotBlank()) {
+                        Text(
+                            sub,
+                            style = MiuixTheme.textStyles.footnote1,
+                            color = if (state != null && state != ZYXF_DOWNLOADING) {
+                                MiuixTheme.colorScheme.primary
+                            } else {
+                                MiuixTheme.colorScheme.onSurfaceVariantSummary
+                            },
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                }
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    if (item.isFolder) "打开" else if (busy) "…" else "下载",
+                    style = MiuixTheme.textStyles.footnote1,
+                    fontWeight = FontWeight.Medium,
+                    color = MiuixTheme.colorScheme.primary,
+                )
+            }
+        }
+        if (w.items.size > shown.size) {
+            Text(
+                "…还有 ${w.items.size - shown.size} 条，换个更具体的关键词能更快找到",
+                style = MiuixTheme.textStyles.footnote1,
+                color = MiuixTheme.colorScheme.onSurfaceVariantSummary,
+                modifier = Modifier.padding(top = 4.dp),
+            )
         }
     }
 }

--- a/app/src/main/java/com/xjtu/toolbox/calendar/SchoolCalendarScreen.kt
+++ b/app/src/main/java/com/xjtu/toolbox/calendar/SchoolCalendarScreen.kt
@@ -51,9 +51,7 @@ fun SchoolCalendarScreen(site: SiteSession?, onBack: () -> Unit) {
         try {
             val result = withContext(Dispatchers.IO) { api.getTerms() }
             terms = result
-            // 默认选中当前学期
-            val currentIdx = result.indexOfFirst { it.currentWeek(today) > 0 }
-            selectedTermIndex = if (currentIdx >= 0) currentIdx else 0
+            selectedTermIndex = defaultTermIndex(result, today)
         } catch (e: kotlinx.coroutines.CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -133,6 +131,21 @@ fun SchoolCalendarScreen(site: SiteSession?, onBack: () -> Unit) {
             }
         }
     }
+}
+
+/**
+ * 进来先看哪个学期：正在进行的 → 最近要开始的 → 最后一个。
+ *
+ * 原来只找"正在进行"，找不到就落回 `terms[0]`。而 [SchoolCalendarApi.getTerms] 是按
+ * 开学日期升序排的，`terms[0]` 是**最老**的那个学期——于是寒暑假、开学前这些不在任何
+ * 学期区间内的日子，校历页一打开显示的是好几年前的校历，看着就像"新校历没加进来"。
+ * 学校其实早就发了（这个页面本来就是实时拉的门户数据，没有任何本地写死的年份）。
+ */
+internal fun defaultTermIndex(terms: List<SchoolTerm>, today: LocalDate): Int {
+    if (terms.isEmpty()) return 0
+    terms.indexOfFirst { it.currentWeek(today) > 0 }.takeIf { it >= 0 }?.let { return it }
+    terms.indexOfFirst { today < it.startDate }.takeIf { it >= 0 }?.let { return it }
+    return terms.lastIndex
 }
 
 @Composable

--- a/app/src/main/java/com/xjtu/toolbox/library/LibraryApi.kt
+++ b/app/src/main/java/com/xjtu/toolbox/library/LibraryApi.kt
@@ -132,8 +132,14 @@ class LibraryApi(private val site: SiteSession) {
             }
         }
 
-        /** 从 scount 原始数据中只保留和 AREA_MAP value 匹配的独立区域 code */
-        private val VALID_AREA_CODES = AREA_MAP.values.toSet()
+        /**
+         * 兴庆的区域码。
+         *
+         * 以前它叫 VALID_AREA_CODES，是 `filterScount` 的白名单——于是雁塔、创新港的
+         * 区域码一律被当成"无效"滤掉，两个校区的区域列表永远是空的（issue #42）。
+         * 现在白名单由 [knownAreaCodes] 在运行时从 `/qspace` 学，这份只当兴庆的兜底。
+         */
+        private val XINGQING_AREA_CODES = AREA_MAP.values.toSet()
 
         /** 反向映射：areaCode → 区域显示名 */
         val AREA_MAP_REVERSE = AREA_MAP.entries.associate { (name, code) -> code to name }
@@ -177,8 +183,19 @@ class LibraryApi(private val site: SiteSession) {
          */
         val URGENT_ACTIONS = setOf("入馆签到", "中途返回")
 
-        fun filterScount(raw: Map<String, AreaStats>): Map<String, AreaStats> =
-            raw.filterKeys { it in VALID_AREA_CODES }
+        /**
+         * scount 里混着区域码和一些非区域的键（楼层汇总之类），要挑出真正的区域。
+         *
+         * @param known 本次已从 `/qspace` 学到的区域码。为空（还没拉到楼层信息）时
+         *              退回兴庆那张静态表——否则首屏会连兴庆都滤没。
+         */
+        fun filterScount(
+            raw: Map<String, AreaStats>,
+            known: Set<String> = emptySet(),
+        ): Map<String, AreaStats> {
+            val allow = if (known.isEmpty()) XINGQING_AREA_CODES else known + XINGQING_AREA_CODES
+            return raw.filterKeys { it in allow }
+        }
 
         fun guessAreaCode(seatId: String): String? {
             val prefix = seatId.firstOrNull()?.uppercaseChar() ?: return null
@@ -203,6 +220,124 @@ class LibraryApi(private val site: SiteSession) {
     @Volatile
     var cachedAreaStats: Map<String, AreaStats> = emptyMap()
         private set
+
+    /**
+     * 运行时学到的「区域码 → 中文名」，来源是 `/qspace?floor=…` 的 `sp` 字段。
+     *
+     * 兴庆那张 [AREA_MAP] 是手抄的，抄不到雁塔和创新港；这份跟着用户翻到哪层就学到哪层，
+     * 三个校区一视同仁，学校改名也不用发版。
+     */
+    private val learnedAreaNames = java.util.concurrent.ConcurrentHashMap<String, String>()
+
+    /** 区域码 → 所在楼层码。`qseat` 之前要先 `qspace` 定位楼层，这张表就是给它用的。 */
+    private val learnedAreaFloors = java.util.concurrent.ConcurrentHashMap<String, String>()
+
+    /** 已知区域码：学到的 + 兴庆静态表。 */
+    fun knownAreaCodes(): Set<String> = learnedAreaNames.keys + AREA_MAP.values
+
+    /** 已知区域中文名，用于从预约页面文本里认出「我预约在哪个区」。 */
+    fun knownAreaNames(): Set<String> = learnedAreaNames.values.toSet() + AREA_MAP.keys
+
+    fun areaNameOf(areaCode: String): String =
+        learnedAreaNames[areaCode] ?: AREA_MAP_REVERSE[areaCode] ?: areaCode
+
+    private fun floorCodeOf(areaCode: String): String? =
+        learnedAreaFloors[areaCode] ?: AREA_FLOOR_CODES[areaCode]
+
+    /**
+     * 拉一层的区域列表（码 → 中文名），顺带把 scount 更新掉。
+     *
+     * `qspace` **跟着账号当前校区走**：查别的校区之前必须先 [switchCampus]，
+     * 否则拿回来的还是当前校区那几层。
+     */
+    fun getFloorAreas(floorCode: String): Map<String, String> {
+        val (response, body) = executeWithReAuth(
+            buildRequest("$BASE_URL/qspace?lang=zh&floor=$floorCode", ajax = true, referer = "$BASE_URL/seat/")
+        )
+        response.close()
+        if (!response.isSuccessful) throw RuntimeException("楼层信息加载失败: HTTP ${response.code}")
+        if (!looksLikeJson(body)) {
+            Log.e(TAG, "qspace(floor=$floorCode) not JSON: ${body.take(300)}")
+            throw RuntimeException("图书馆楼层信息接口返回异常（非 JSON 响应）")
+        }
+        val json = org.json.JSONObject(body)
+        val result = linkedMapOf<String, String>()
+        json.optJSONObject("sp")?.let { sp ->
+            val keys = sp.keys()
+            while (keys.hasNext()) {
+                val code = keys.next()
+                if (code.isBlank()) continue
+                val name = sp.optString(code).takeIf { it.isNotBlank() } ?: continue
+                result[code] = name
+                learnedAreaNames[code] = name
+                learnedAreaFloors[code] = floorCode
+            }
+        }
+        parseAreaStats(json.optJSONObject("scount")).let { stats ->
+            cachedAreaStats = filterScount(stats, knownAreaCodes()).ifEmpty { cachedAreaStats }
+        }
+        Log.d(TAG, "getFloorAreas($floorCode): ${result.size} areas")
+        return result
+    }
+
+    /**
+     * 账号当前所在校区。解析 `/modify` 页 `select#rplace` 的选中项，认不出返回 null。
+     */
+    fun getCurrentCampus(): LibraryCampus? = try {
+        val (response, body) = executeWithReAuth(buildRequest("$BASE_URL/modify"))
+        response.close()
+        val selected = Jsoup.parse(body).select("select#rplace option[selected]").firstOrNull()?.attr("value")
+        LibraryCampus.byId(selected)
+    } catch (e: Exception) {
+        Log.w(TAG, "getCurrentCampus failed", e)
+        null
+    }
+
+    /**
+     * 切换账号校区。
+     *
+     * **这会改用户在图书馆系统里的个人资料**（`rplace` 是账号级字段，不是一次查询的参数），
+     * 所以只能由用户在校区选择器里主动触发，不要在后台自动切。表单要把邮箱、电话原样回填
+     * 再提交，少一个字段服务端会把它清空——切个校区顺手抹掉联系方式，用户是不会想到的。
+     */
+    fun switchCampus(campus: LibraryCampus): Boolean = try {
+        val (formResp, formHtml) = executeWithReAuth(buildRequest("$BASE_URL/modify"))
+        formResp.close()
+        val doc = Jsoup.parse(formHtml)
+        val csrf = doc.select("input[name=csrf_token]").firstOrNull()?.attr("value").orEmpty()
+        val email = doc.select("#email").firstOrNull()?.attr("value").orEmpty()
+        val tel = doc.select("#tel").firstOrNull()?.attr("value").orEmpty()
+        if (csrf.isBlank()) {
+            Log.w(TAG, "switchCampus: no csrf_token in /modify")
+            false
+        } else {
+            val form = okhttp3.FormBody.Builder()
+                .add("csrf_token", csrf)
+                .add("email", email)
+                .add("tel", tel)
+                .add("rplace", campus.id)
+                .add("subit", "确认")
+                .build()
+            val req = Request.Builder().url("$BASE_URL/modify")
+                .header("Referer", "$BASE_URL/modify")
+                .post(form)
+                .build()
+            val resp = runBlocking { site.executeWithReAuth(req) }
+            val ok = resp.isSuccessful
+            resp.close()
+            // 提交完清掉学到的区域：换校区后区域码整套都变了，留着会把上个校区的
+            // 区域混进列表。
+            if (ok) {
+                learnedAreaNames.clear()
+                learnedAreaFloors.clear()
+                cachedAreaStats = emptyMap()
+            }
+            ok
+        }
+    } catch (e: Exception) {
+        Log.w(TAG, "switchCampus failed", e)
+        false
+    }
 
     /**
      * 带有界超时的派生 client：复用底层 cookieJar / interceptor（含 WebVPN），
@@ -240,7 +375,7 @@ class LibraryApi(private val site: SiteSession) {
     // ── 座位查询 ──
 
     private fun loadFloorContext(areaCode: String): Map<String, AreaStats> {
-        val floorCode = AREA_FLOOR_CODES[areaCode] ?: return emptyMap()
+        val floorCode = floorCodeOf(areaCode) ?: return emptyMap()
         val qspaceUrl = "$BASE_URL/qspace?lang=zh&floor=$floorCode"
         val (response, body) = executeWithReAuth(
             buildRequest(qspaceUrl, ajax = true, referer = "$BASE_URL/seat/")
@@ -257,7 +392,7 @@ class LibraryApi(private val site: SiteSession) {
         }
         val json = org.json.JSONObject(body)
         val stats = parseAreaStats(json.optJSONObject("scount"))
-        cachedAreaStats = filterScount(stats)
+        cachedAreaStats = filterScount(stats, knownAreaCodes())
         return cachedAreaStats
     }
 
@@ -283,7 +418,7 @@ class LibraryApi(private val site: SiteSession) {
             // The site stores the selected floor in session state. Mirror the browser's
             // HAR sequence: qspace(floor) -> qseat(area).
             loadFloorContext(areaCode)
-            val floorCode = AREA_FLOOR_CODES[areaCode]
+            val floorCode = floorCodeOf(areaCode)
             val referer = if (floorCode != null) "$BASE_URL/qspace?lang=zh&floor=$floorCode"
                 else "$BASE_URL/seat/"
             // 走 executeWithReAuth：命中登录页会自动 reAuthenticate，
@@ -325,7 +460,7 @@ class LibraryApi(private val site: SiteSession) {
 
             // 解析 scount（全局区域统计）
             val statsMap = parseAreaStats(json.optJSONObject("scount"))
-            cachedAreaStats = filterScount(statsMap).ifEmpty { cachedAreaStats }
+            cachedAreaStats = filterScount(statsMap, knownAreaCodes()).ifEmpty { cachedAreaStats }
             Log.d(TAG, "scount: ${cachedAreaStats.size} areas open")
 
             // 解析 seat 对象
@@ -550,7 +685,7 @@ class LibraryApi(private val site: SiteSession) {
         if (statusMatches.isEmpty()) {
             // 无明确状态标记，回退：找第一个座位号
             val seatId = SEAT_ID_REGEX.find(bodyText)?.value ?: return null
-            val area = AREA_MAP.keys.firstOrNull { it in bodyText }
+            val area = knownAreaNames().firstOrNull { it in bodyText }
             val actionUrls = parseActionsFromHtml(doc, html)
             Log.d(TAG, "getMyBooking (no status): seatId=$seatId, area=$area")
             return MyBookingInfo(seatId, area, null, actionUrls)
@@ -574,7 +709,7 @@ class LibraryApi(private val site: SiteSession) {
                 continue
             }
 
-            val area = AREA_MAP.keys.firstOrNull { it in blockText }
+            val area = knownAreaNames().firstOrNull { it in blockText }
             val actionUrls = parseActionsFromHtml(doc, html)
 
             Log.d(TAG, "getMyBooking: seatId=$seatId, area=$area, status=$status, actions=${actionUrls.keys}")

--- a/app/src/main/java/com/xjtu/toolbox/library/LibraryCampus.kt
+++ b/app/src/main/java/com/xjtu/toolbox/library/LibraryCampus.kt
@@ -1,0 +1,59 @@
+package com.xjtu.toolbox.library
+
+/**
+ * 图书馆的三个校区。
+ *
+ * 之前整套座位功能只认兴庆：楼层码写死 `xingqing2/3/4floor`，区域名写死一张十三条的
+ * 中文表（[LibraryApi.AREA_MAP]）。雁塔和创新港的同学打开座位页，区域列表是空的——
+ * 因为那两个校区的区域码根本不在那张表里，`filterScount` 一过全被滤掉。
+ *
+ * 这一版换个思路：
+ * - **校区和楼层码写死**，它们是学校系统里固定的枚举，且数量极少；
+ * - **区域名不写死**，改成每层现拉 `/qspace?floor=…` 的 `sp` 字段。
+ *   兴庆那张表能手抄是因为有人一个个点过，雁塔、创新港没人点，抄不出来也不该抄——
+ *   学校改个区域名，写死的表就又要发版。
+ *
+ * 校区 ID / 楼层码取自 yan-xiaoo/XJTUToolBox 对 `/seatui` floor-selector 的实测
+ * （见该仓库 `library/seats.py`）。
+ */
+enum class LibraryCampus(
+    /** 学校系统里的校区 ID，就是 `/modify` 页面 `select#rplace` 的 option value。 */
+    val id: String,
+    val displayName: String,
+    /** 该校区的楼层码，按楼层升序。 */
+    val floorCodes: List<String>,
+) {
+    XINGQING("east", "兴庆", listOf("xingqing2floor", "xingqing3floor", "xingqing4floor")),
+    YANTA("west", "雁塔", listOf("yanta1floor", "yanta2floor", "yanta3floor", "yanta4floor")),
+    INNOVATION("inno", "创新港", listOf("inno1floor", "inno2floor")),
+    ;
+
+    /** 楼层码 → 「三楼」这样的显示名。 */
+    fun floorLabel(floorCode: String): String {
+        val n = FLOOR_NUMBER.find(floorCode)?.groupValues?.get(1)?.toIntOrNull()
+            ?: return floorCode
+        return "${CHINESE_DIGITS.getOrNull(n) ?: n.toString()}楼"
+    }
+
+    companion object {
+        private val FLOOR_NUMBER = Regex("""(\d+)floor""")
+        private val CHINESE_DIGITS = listOf("零", "一", "二", "三", "四", "五", "六", "七", "八", "九")
+
+        val DEFAULT = XINGQING
+
+        fun byId(id: String?): LibraryCampus? = entries.firstOrNull { it.id == id?.trim() }
+
+        /**
+         * 反推楼层码属于哪个校区。
+         *
+         * 只按前缀匹配，不按 [floorCodes] 精确匹配：万一学校加了一层
+         * （`yanta5floor` 之类），前缀照样认得出，不至于整个校区哑掉。
+         */
+        fun byFloorCode(floorCode: String): LibraryCampus? = when {
+            floorCode.startsWith("xingqing") -> XINGQING
+            floorCode.startsWith("yanta") -> YANTA
+            floorCode.startsWith("inno") -> INNOVATION
+            else -> null
+        }
+    }
+}

--- a/app/src/main/java/com/xjtu/toolbox/library/LibraryScreen.kt
+++ b/app/src/main/java/com/xjtu/toolbox/library/LibraryScreen.kt
@@ -87,6 +87,24 @@ private fun loadFavorites(ctx: Context): Set<String> =
 private fun saveFavorites(ctx: Context, favs: Set<String>) =
     ctx.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE).edit().putStringSet(KEY_FAVORITES, favs).apply()
 
+// ══════ 校区偏好 ══════
+
+private const val KEY_CAMPUS = "library_campus"
+
+/**
+ * 上次用的校区。仅作首屏的乐观展示——真正以账号里的 `rplace` 为准，
+ * 进页面后会用 [LibraryApi.getCurrentCampus] 校一次。
+ */
+private fun loadPreferredCampus(ctx: Context): LibraryCampus =
+    LibraryCampus.byId(
+        ctx.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE).getString(KEY_CAMPUS, null)
+    ) ?: LibraryCampus.DEFAULT
+
+private fun savePreferredCampus(ctx: Context, campus: LibraryCampus) {
+    ctx.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
+        .edit().putString(KEY_CAMPUS, campus.id).apply()
+}
+
 // ══════ LibraryScreen ══════
 
 @Composable
@@ -130,43 +148,38 @@ fun LibraryScreen(site: SiteSession, onBack: () -> Unit) {
     // 收藏
     var favorites by remember { mutableStateOf(loadFavorites(context)) }
 
-    // ── 楼层/区域选择 ──
-    val allFloors = remember { LibraryApi.FLOORS.keys.toList() }
-    val floors = remember(allFloors, areaStatsMap) {
-        if (areaStatsMap.isEmpty()) allFloors
-        else allFloors.filter { floor ->
-            val floorAreas = LibraryApi.FLOORS[floor] ?: emptyList()
-            floorAreas.any { area ->
-                val code = LibraryApi.AREA_MAP[area] ?: return@any false
-                areaStatsMap[code]?.isOpen == true
-            }
-        }
-    }
-    var selectedFloor by remember { mutableStateOf(allFloors.first()) }
-    LaunchedEffect(floors) {
-        if (selectedFloor !in floors && floors.isNotEmpty()) selectedFloor = floors.first()
-    }
+    // ── 校区/楼层/区域选择 ──
+    //
+    // 三级都是运行时定的：校区来自账号设置，楼层来自 [LibraryCampus]，
+    // 区域来自 `/qspace` 现拉。原来这里挂的是兴庆那张写死的表，
+    // 雁塔和创新港的区域码一个都对不上，两个校区的列表永远空着（issue #42）。
+    var campus by remember { mutableStateOf(loadPreferredCampus(context)) }
+    var campusSwitching by remember { mutableStateOf(false) }
+    var selectedFloorCode by remember(campus) { mutableStateOf(campus.floorCodes.first()) }
 
-    val allAreas = remember(selectedFloor) { LibraryApi.FLOORS[selectedFloor] ?: emptyList() }
-    // scount 未加载时不显示区域，避免未开放区域闪烁
-    val areas = remember(allAreas, areaStatsMap) {
-        if (areaStatsMap.isEmpty()) emptyList()
-        else allAreas.filter { area ->
-            val code = LibraryApi.AREA_MAP[area] ?: return@filter false
-            areaStatsMap[code]?.isOpen == true
-        }
-    }
-    var selectedArea by remember(selectedFloor) { mutableStateOf(areas.firstOrNull() ?: "") }
-    LaunchedEffect(areas) {
-        if (selectedArea !in areas) selectedArea = areas.firstOrNull() ?: ""
+    /** 当前楼层的「区域码 → 中文名」，顺序即学校给的顺序。 */
+    var floorAreas by remember { mutableStateOf<Map<String, String>>(emptyMap()) }
+    var selectedAreaCode by remember { mutableStateOf("") }
+    val selectedArea = floorAreas[selectedAreaCode] ?: api.areaNameOf(selectedAreaCode)
+
+    val floors = remember(campus) { campus.floorCodes.map { campus.floorLabel(it) } }
+
+    /**
+     * 可选区域。
+     *
+     * 只把**明确关闭**（scount 里有这个区域且 total=0）的滤掉。原来的写法是反过来的：
+     * 只留明确开放的，于是统计还没到、或者学校压根没给这个区域统计时，列表是空的——
+     * 那正是另外两个校区看到的样子。
+     */
+    val areaCodes = remember(floorAreas, areaStatsMap) {
+        floorAreas.keys.filter { code -> areaStatsMap[code]?.isOpen != false }
     }
 
     // 智能推荐座位
-    val recommendedSeats by remember(seats, selectedArea) {
+    val recommendedSeats by remember(seats, selectedAreaCode) {
         derivedStateOf {
-            val areaCode = LibraryApi.AREA_MAP[selectedArea] ?: return@derivedStateOf emptyList()
-            if (seats.isEmpty()) return@derivedStateOf emptyList()
-            api.recommendSeats(seats, areaCode, topN = 5)
+            if (selectedAreaCode.isEmpty() || seats.isEmpty()) return@derivedStateOf emptyList()
+            api.recommendSeats(seats, selectedAreaCode, topN = 5)
         }
     }
 
@@ -200,26 +213,95 @@ fun LibraryScreen(site: SiteSession, onBack: () -> Unit) {
     }
 
     fun loadSeats(force: Boolean = false) {
-        LibraryApi.AREA_MAP[selectedArea]?.let { loadSeatsFor(it, force) }
+        selectedAreaCode.takeIf { it.isNotEmpty() }?.let { loadSeatsFor(it, force) }
     }
 
-    // 区域变化 → 自动加载（与首次 bootstrap 去重，同一区域不打第二枪）
-    LaunchedEffect(selectedArea) {
-        if (selectedArea.isNotEmpty()) {
-            LibraryApi.AREA_MAP[selectedArea]?.let { loadSeatsFor(it) }
+    /** 拉一层的区域列表并选中第一个可用区域。换校区、换楼层都走这里。 */
+    fun loadFloor(floorCode: String) {
+        selectedFloorCode = floorCode
+        isLoading = true
+        scope.launch {
+            try {
+                val result = withContext(Dispatchers.IO) { api.getFloorAreas(floorCode) }
+                floorAreas = result
+                errorMessage = if (result.isEmpty()) "这一层没有可选区域" else null
+                val code = result.keys.firstOrNull { api.cachedAreaStats[it]?.isOpen != false }
+                    ?: result.keys.firstOrNull().orEmpty()
+                selectedAreaCode = code
+                if (code.isEmpty()) {
+                    // 没有区域可选，这一枪到此为止——否则转圈永远不停。
+                    seats = emptyList()
+                    isLoading = false
+                } else {
+                    // 直接拉，不等 LaunchedEffect(selectedAreaCode)：换走一层再换回来时
+                    // code 和上次相同，那个 effect 根本不会重跑，isLoading 就吊在 true 上。
+                    // 这里 force 拉一次并占住 lastLoadedAreaCode，effect 真跑起来也会被去重挡掉。
+                    loadSeatsFor(code, force = true)
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: AuthExpiredException) {
+                appLoginState.handleAuthExpired(LoginType.LIBRARY, Routes.LIBRARY, onBack)
+                isLoading = false
+            } catch (e: Exception) {
+                floorAreas = emptyMap()
+                seats = emptyList()
+                errorMessage = "楼层信息加载失败: ${e.message}"
+                isLoading = false
+            }
         }
     }
 
-    // 首次 bootstrap：加载 scount + 预约信息
+    // 区域变化 → 自动加载（与首次 bootstrap 去重，同一区域不打第二枪）
+    LaunchedEffect(selectedAreaCode) {
+        if (selectedAreaCode.isNotEmpty()) loadSeatsFor(selectedAreaCode)
+    }
+
+    // 首次 bootstrap：认账号当前校区 → 拉第一层的区域 → 拉预约信息
     LaunchedEffect(Unit) {
-        val bootstrapCode = allAreas.firstOrNull()?.let { LibraryApi.AREA_MAP[it] }
-        if (bootstrapCode != null) loadSeatsFor(bootstrapCode)
+        // 以账号在图书馆系统里实际选的校区为准。本地记的那个可能是上次装机时的，
+        // 也可能用户在网页端改过；不问一声就按本地的画，会画出一个空列表。
+        val actual = withContext(Dispatchers.IO) { runCatching { api.getCurrentCampus() }.getOrNull() }
+        if (actual != null && actual != campus) {
+            campus = actual
+            savePreferredCampus(context, actual)
+        }
+        loadFloor((actual ?: campus).floorCodes.first())
         try { myBooking = withContext(Dispatchers.IO) { api.getMyBooking() } } catch (_: Exception) {}
+    }
+
+    /**
+     * 换校区。
+     *
+     * 这一步会改用户在图书馆系统里的个人资料（`rplace`），所以只在用户点校区标签时做，
+     * 不在后台自动切——见 [LibraryApi.switchCampus]。
+     */
+    fun switchCampus(target: LibraryCampus) {
+        if (target == campus || campusSwitching) return
+        campusSwitching = true
+        scope.launch {
+            val ok = withContext(Dispatchers.IO) {
+                runCatching { api.switchCampus(target) }.getOrDefault(false)
+            }
+            if (ok) {
+                campus = target
+                savePreferredCampus(context, target)
+                floorAreas = emptyMap()
+                selectedAreaCode = ""
+                seats = emptyList()
+                areaStatsMap = emptyMap()
+                lastLoadedAreaCode = null
+                loadFloor(target.floorCodes.first())
+            } else {
+                errorMessage = "切换到" + target.displayName + "失败，请稍后重试"
+            }
+            campusSwitching = false
+        }
     }
 
     // 预约/换座/取消后只刷新一轮：座位 + 我的预约并行，不再各走一遍
     suspend fun refreshAfterBooking() = coroutineScope {
-        val areaCode = LibraryApi.AREA_MAP[selectedArea]
+        val areaCode = selectedAreaCode.takeIf { it.isNotEmpty() }
         val seatsDeferred = if (areaCode != null) {
             lastLoadedAreaCode = areaCode
             async(Dispatchers.IO) { api.getSeats(areaCode) }
@@ -239,7 +321,7 @@ fun LibraryScreen(site: SiteSession, onBack: () -> Unit) {
 
     // ── 预约 ──
     fun doBookSeat(seatId: String) {
-        val areaCode = LibraryApi.AREA_MAP[selectedArea]
+        val areaCode = selectedAreaCode.takeIf { it.isNotEmpty() }
             ?: LibraryApi.guessAreaCode(seatId)
             ?: run { bookingResult = BookResult(false, "无法确定区域"); return }
         isBooking = true; bookingResult = null
@@ -258,7 +340,7 @@ fun LibraryScreen(site: SiteSession, onBack: () -> Unit) {
 
     // 直接换座（已知有现有预约时使用）
     fun doSwapSeat(seatId: String) {
-        val areaCode = LibraryApi.AREA_MAP[selectedArea]
+        val areaCode = selectedAreaCode.takeIf { it.isNotEmpty() }
             ?: LibraryApi.guessAreaCode(seatId)
             ?: run { bookingResult = BookResult(false, "无法确定区域"); return }
         isBooking = true; bookingResult = null
@@ -323,7 +405,7 @@ fun LibraryScreen(site: SiteSession, onBack: () -> Unit) {
     // 地图/列表视图切换
     var showMapView by remember { mutableStateOf(false) }
     var seatScope by rememberSaveable { mutableStateOf("可用") }
-    val currentAreaCode = LibraryApi.AREA_MAP[selectedArea] ?: ""
+    val currentAreaCode = selectedAreaCode
     val mapAvailable = currentAreaCode in MAP_SUPPORTED_AREAS
 
     val availableCount = seats.count { it.available }
@@ -545,42 +627,63 @@ fun LibraryScreen(site: SiteSession, onBack: () -> Unit) {
                 }
             }
 
-            // ── 楼层/区域选择器 (一体化) ──
-            if (floors.isNotEmpty() || areas.isNotEmpty()) {
-                Card(
-                    modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 6.dp),
-                    colors = CardDefaults.defaultColors(color = MiuixTheme.colorScheme.secondaryContainer)
-                ) {
-                    Column {
-                        if (floors.isNotEmpty()) {
-                            AppSegmentedTabs(
-                                tabs = floors,
-                                selectedTabIndex = (floors.indexOf(selectedFloor)).coerceAtLeast(0),
-                                onTabSelected = { selectedFloor = floors.getOrElse(it) { floors.first() } },
-                                embedded = true,
+            // ── 校区/楼层/区域选择器 (一体化) ──
+            Card(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 6.dp),
+                colors = CardDefaults.defaultColors(color = MiuixTheme.colorScheme.secondaryContainer)
+            ) {
+                Column {
+                    // 校区。切换会写回账号资料（rplace），所以切换期间禁用整排，
+                    // 避免用户连点两下把请求打叉。
+                    Row(
+                        Modifier
+                            .fillMaxWidth()
+                            .horizontalScroll(rememberScrollState())
+                            .padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 2.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        LibraryCampus.entries.forEach { c ->
+                            com.xjtu.toolbox.ui.components.AppFilterChip(
+                                selected = campus == c,
+                                onClick = { if (!campusSwitching) switchCampus(c) },
+                                label = c.displayName
                             )
                         }
-                        if (floors.isNotEmpty() && areas.isNotEmpty()) {
-                            HorizontalDivider(
-                                modifier = Modifier.padding(horizontal = 16.dp),
-                                color = MiuixTheme.colorScheme.outline.copy(alpha = 0.08f)
-                            )
+                        if (campusSwitching) {
+                            CircularProgressIndicator(size = 14.dp, strokeWidth = 2.dp)
                         }
-                        if (areas.isNotEmpty()) {
-                            Row(
-                                Modifier
-                                    .fillMaxWidth()
-                                    .horizontalScroll(rememberScrollState())
-                                    .padding(horizontal = 16.dp, vertical = 6.dp),
-                                horizontalArrangement = Arrangement.spacedBy(8.dp)
-                            ) {
-                                areas.forEach { area ->
-                                    com.xjtu.toolbox.ui.components.AppFilterChip(
-                                        selected = selectedArea == area,
-                                        onClick = { selectedArea = area },
-                                        label = area
-                                    )
-                                }
+                    }
+                    if (floors.isNotEmpty()) {
+                        AppSegmentedTabs(
+                            tabs = floors,
+                            selectedTabIndex = campus.floorCodes.indexOf(selectedFloorCode).coerceAtLeast(0),
+                            onTabSelected = { index ->
+                                campus.floorCodes.getOrNull(index)?.let { loadFloor(it) }
+                            },
+                            embedded = true,
+                        )
+                    }
+                    if (floors.isNotEmpty() && areaCodes.isNotEmpty()) {
+                        HorizontalDivider(
+                            modifier = Modifier.padding(horizontal = 16.dp),
+                            color = MiuixTheme.colorScheme.outline.copy(alpha = 0.08f)
+                        )
+                    }
+                    if (areaCodes.isNotEmpty()) {
+                        Row(
+                            Modifier
+                                .fillMaxWidth()
+                                .horizontalScroll(rememberScrollState())
+                                .padding(horizontal = 16.dp, vertical = 6.dp),
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            areaCodes.forEach { code ->
+                                com.xjtu.toolbox.ui.components.AppFilterChip(
+                                    selected = selectedAreaCode == code,
+                                    onClick = { selectedAreaCode = code },
+                                    label = floorAreas[code] ?: code
+                                )
                             }
                         }
                     }

--- a/app/src/main/java/com/xjtu/toolbox/schedule/ScheduleCache.kt
+++ b/app/src/main/java/com/xjtu/toolbox/schedule/ScheduleCache.kt
@@ -90,9 +90,7 @@ object ScheduleCache {
             val newBits = StringBuilder(course.weekBits)
             for (i in newBits.indices) {
                 if (newBits[i] == '1') {
-                    val courseDate = startOfTerm
-                        .plusWeeks(i.toLong())
-                        .plusDays((course.dayOfWeek - 1).toLong())
+                    val courseDate = TermWeeks.dateOf(startOfTerm, i + 1, course.dayOfWeek)
                     if (holidayDates.containsKey(courseDate)) {
                         newBits.setCharAt(i, '0')
                         changed = true
@@ -121,7 +119,7 @@ object ScheduleCache {
     fun isFinishedByDate(startOfTerm: LocalDate?, weeks: Int, today: LocalDate = LocalDate.now()): Boolean {
         if (startOfTerm == null || weeks <= 0) return false
         // 多留一周缓冲：最后一周还可能补录考勤、传回放。
-        return today.isAfter(startOfTerm.plusWeeks((weeks + 1).toLong()))
+        return TermWeeks.weekOf(startOfTerm, today) > weeks + 1
     }
 
     /**

--- a/app/src/main/java/com/xjtu/toolbox/schedule/ScheduleScreen.kt
+++ b/app/src/main/java/com/xjtu/toolbox/schedule/ScheduleScreen.kt
@@ -110,7 +110,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.withContext
 import java.time.LocalDate
-import java.time.temporal.ChronoUnit
 
 private data class ScheduleDiskSnapshot(
     val termList: List<String> = emptyList(),
@@ -199,8 +198,7 @@ fun ScheduleScreen(
     val initialWeek = remember(disk.startDate) {
         val startDate = disk.startDate ?: return@remember 0
         try {
-            val daysBetween = ChronoUnit.DAYS.between(startDate, LocalDate.now())
-            val w = ((daysBetween / 7) + 1).toInt()
+            val w = TermWeeks.weekOf(startDate)
             // 这里还拿不到 totalWeeks（依赖 courses），先用磁盘快照估一次。
             val diskWeeks = disk.courses.maxOfOrNull { it.weekBits.length }?.takeIf { it > 0 } ?: 30
             if (w in 1..diskWeeks) w else 0
@@ -216,6 +214,15 @@ fun ScheduleScreen(
     val totalWeeks = remember(courses) {
         courses.maxOfOrNull { it.weekBits.length }?.takeIf { it > 0 } ?: 0
     }
+
+    /**
+     * 现算一遍学期周数，不走 [totalWeeks] 那个 remember。
+     *
+     * 加载流程里"先赋值 courses，紧接着算周次"是同一帧内的事，而 `totalWeeks` 是本次
+     * 组合期间算好的 val，那一刻还是旧值（冷启动时就是 0）。0 会被当成"学期只有 0 周"，
+     * 于是任何周次都 > 0，页面报"学期已结束"。这里直接读 state，拿到的永远是最新的。
+     */
+    fun knownTotalWeeks(): Int = courses.maxOfOrNull { it.weekBits.length }?.takeIf { it > 0 } ?: 0
     var selectedTab by rememberSaveable { mutableIntStateOf(0) }
 
     /**
@@ -292,27 +299,18 @@ fun ScheduleScreen(
     fun applyTermStart(startDate: LocalDate) {
         startOfTerm = startDate
         try {
-            val today = LocalDate.now()
-            val daysBetween = ChronoUnit.DAYS.between(startDate, today)
-            val rawWeek = ((daysBetween / 7) + 1).toInt()
-            if (rawWeek in 1..totalWeeks) realCurrentWeek = rawWeek
-            val firstTeachWeek = courses.flatMap { c ->
-                c.weekBits.indices.filter { c.weekBits[it] == '1' }.map { it + 1 }
-            }.minOrNull()
-            val notStarted = rawWeek in 1..totalWeeks &&
-                    firstTeachWeek != null && rawWeek < firstTeachWeek
-            currentWeek = when {
-                rawWeek <= 0 -> 1
-                rawWeek > totalWeeks -> { showAllWeeks = true; 1 }
-                notStarted -> firstTeachWeek
-                else -> rawWeek
-            }
-            weekNote = when {
-                rawWeek <= 0 -> "距开学还有 ${1 - rawWeek} 周"
-                rawWeek > totalWeeks -> "学期已结束"
-                notStarted -> "尚未开课 · 第${firstTeachWeek}周开始上课"
-                else -> null
-            }
+            // totalWeeks 取自 courses，这一帧里 courses 可能刚被赋值而它还是旧的；
+            // 直接现算一遍，别让"课表已经到了但周数还是 0"的中间态判成学期结束。
+            val weeks = knownTotalWeeks()
+            val status = TermWeeks.statusOf(
+                startOfTerm = startDate,
+                totalWeeks = weeks,
+                firstTeachWeek = TermWeeks.firstTeachWeekOf(courses),
+            )
+            if (status is TermWeeks.Status.InTerm) realCurrentWeek = status.week
+            if (status is TermWeeks.Status.AfterTerm) showAllWeeks = true
+            currentWeek = TermWeeks.displayWeekOf(status)
+            weekNote = TermWeeks.noteOf(status)
         } catch (_: Exception) {
             currentWeek = 1
             weekNote = null
@@ -896,26 +894,14 @@ fun ScheduleScreen(
                         if (startDate != null) {
                             startOfTerm = startDate
                             if (api != null) try { dataCache.put("start_date_$newTermCode", gson.toJson(startDate.toString())) } catch (_: Exception) {}
-                            val today = LocalDate.now()
-                            val daysBetween = ChronoUnit.DAYS.between(startDate, today)
-                            val rawWeek = ((daysBetween / 7) + 1).toInt()
-                            val firstTeachWeek = courses.flatMap { c ->
-                                c.weekBits.indices.filter { c.weekBits[it] == '1' }.map { it + 1 }
-                            }.minOrNull()
-                            val notStarted = rawWeek in 1..totalWeeks &&
-                                    firstTeachWeek != null && rawWeek < firstTeachWeek
-                            currentWeek = when {
-                                rawWeek <= 0 -> 1
-                                rawWeek > totalWeeks -> { showAllWeeks = true; 1 }
-                                notStarted -> firstTeachWeek
-                                else -> rawWeek
-                            }
-                            weekNote = when {
-                                rawWeek <= 0 -> "距开学还有 ${1 - rawWeek} 周"
-                                rawWeek > totalWeeks -> "学期已结束"
-                                notStarted -> "尚未开课 · 第${firstTeachWeek}周开始上课"
-                                else -> null
-                            }
+                            val status = TermWeeks.statusOf(
+                                startOfTerm = startDate,
+                                totalWeeks = knownTotalWeeks(),
+                                firstTeachWeek = TermWeeks.firstTeachWeekOf(courses),
+                            )
+                            if (status is TermWeeks.Status.AfterTerm) showAllWeeks = true
+                            currentWeek = TermWeeks.displayWeekOf(status)
+                            weekNote = TermWeeks.noteOf(status)
                         } else {
                             currentWeek = 1; weekNote = null
                         }

--- a/app/src/main/java/com/xjtu/toolbox/schedule/TermWeeks.kt
+++ b/app/src/main/java/com/xjtu/toolbox/schedule/TermWeeks.kt
@@ -1,0 +1,111 @@
+package com.xjtu.toolbox.schedule
+
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+
+/**
+ * 学期周次计算。
+ *
+ * 原来这段逻辑在日程页抄了三份、小部件和屁岱工具各一份，各自都写成
+ * `((ChronoUnit.DAYS.between(start, today) / 7) + 1).toInt()`，于是同一个 bug 也抄了五份：
+ *
+ * 1. **负数向零截断**。Kotlin 的 `/` 对负数截断到 0，开学前 1~6 天算出 `-3 / 7 == 0`，
+ *    周次变成 1——明明还没开学，页面却当成"已经在第 1 周"。再叠上下面第 2 条，
+ *    就是 issue #44 里"开学前夕显示学期已结束"。用 [Math.floorDiv] 向下取整才对。
+ * 2. **周次没锚到周一**。教务的 `XQKSRQ` 正常是周一，但不保证；一旦给的是周中某天，
+ *    之后每个"周次"的分界线都跟着歪，跨周那天会整体差一周。这里统一锚到开学那周的周一。
+ *
+ * 学期总周数（`totalWeeks`）取 `weekBits` 的长度，**课表没拉到时是 0**。0 是"不知道"，
+ * 不是"零周"——[statusOf] 对 0 一律返回 [Status.Unknown]，绝不说"学期已结束"。
+ */
+object TermWeeks {
+
+    /**
+     * 从开学日期算周次。开学当周为 1，开学前为 0、-1、……
+     *
+     * @param startOfTerm 教务下发的学期开始日期
+     */
+    fun weekOf(startOfTerm: LocalDate, date: LocalDate = LocalDate.now()): Int {
+        val anchor = startOfTerm.with(DayOfWeek.MONDAY)
+        val days = ChronoUnit.DAYS.between(anchor, date)
+        return Math.floorDiv(days, 7L).toInt() + 1
+    }
+
+    /** 学期相对今天处在哪个阶段。 */
+    sealed interface Status {
+        /** 还没开学，还差 [weeksAhead] 周（至少 1）。 */
+        data class BeforeTerm(val weeksAhead: Int) : Status
+
+        /** 学期中，当前第 [week] 周。 */
+        data class InTerm(val week: Int) : Status
+
+        /** 已进入学期，但第一门课要到第 [firstTeachWeek] 周才开。 */
+        data class NotStartedYet(val week: Int, val firstTeachWeek: Int) : Status
+
+        /** 学期已结束。 */
+        data object AfterTerm : Status
+
+        /**
+         * 说不准。课表还没拉到（`totalWeeks <= 0`）时就是这个。
+         *
+         * 调用方该做的是**什么都不提示**，按 [fallbackWeek] 正常显示——
+         * 在"不知道"的时候断言"学期已结束"，正是 #44 的表现。
+         */
+        data class Unknown(val fallbackWeek: Int) : Status
+    }
+
+    /**
+     * @param totalWeeks 学期周数，`<= 0` 表示未知（课表还没拉到）
+     * @param firstTeachWeek 第一门课所在周，没有课表时传 null
+     */
+    fun statusOf(
+        startOfTerm: LocalDate,
+        totalWeeks: Int,
+        firstTeachWeek: Int? = null,
+        today: LocalDate = LocalDate.now(),
+    ): Status {
+        val raw = weekOf(startOfTerm, today)
+        return when {
+            raw <= 0 -> Status.BeforeTerm(1 - raw)
+            totalWeeks <= 0 -> Status.Unknown(raw)
+            raw > totalWeeks -> Status.AfterTerm
+            firstTeachWeek != null && raw < firstTeachWeek -> Status.NotStartedYet(raw, firstTeachWeek)
+            else -> Status.InTerm(raw)
+        }
+    }
+
+    /** 页面顶部那行提示。学期中、以及学期未知时都不提示。 */
+    fun noteOf(status: Status): String? = when (status) {
+        is Status.BeforeTerm -> "距开学还有 ${status.weeksAhead} 周"
+        is Status.AfterTerm -> "学期已结束"
+        is Status.NotStartedYet -> "尚未开课 · 第${status.firstTeachWeek}周开始上课"
+        is Status.InTerm, is Status.Unknown -> null
+    }
+
+    /** 该定位到第几周。未开学落在第 1 周，已结束落回第 1 周（由调用方顺便翻成总览）。 */
+    fun displayWeekOf(status: Status): Int = when (status) {
+        is Status.BeforeTerm -> 1
+        is Status.InTerm -> status.week
+        is Status.NotStartedYet -> status.firstTeachWeek
+        is Status.AfterTerm -> 1
+        is Status.Unknown -> status.fallbackWeek.coerceAtLeast(1)
+    }
+
+    /**
+     * 第 [week] 周、星期 [dayOfWeek]（1=周一）对应的日期。
+     *
+     * 与 [weekOf] 用同一个周一锚点——两边只要有一边不锚，"今天是第几周"和
+     * "第几周是哪天"就会对不上，表现为课表整体错位一天或一周。
+     */
+    fun dateOf(startOfTerm: LocalDate, week: Int, dayOfWeek: Int): LocalDate =
+        startOfTerm.with(DayOfWeek.MONDAY)
+            .plusWeeks((week - 1).toLong())
+            .plusDays((dayOfWeek - 1).toLong())
+
+    /** 课表里第一门课在第几周；没课返回 null。 */
+    fun firstTeachWeekOf(courses: List<CourseItem>): Int? = courses
+        .asSequence()
+        .flatMap { c -> c.weekBits.asSequence().mapIndexedNotNull { i, bit -> if (bit == '1') i + 1 else null } }
+        .minOrNull()
+}

--- a/app/src/main/java/com/xjtu/toolbox/util/AppChangelog.kt
+++ b/app/src/main/java/com/xjtu/toolbox/util/AppChangelog.kt
@@ -16,6 +16,14 @@ import com.xjtu.toolbox.bulletin.BulletinRules
  */
 data class VersionChangelog(
     val items: List<Pair<String, String>>,
+    /**
+     * 发版时**仍然存在**的问题，每条写成一句用户看得懂的话
+     * （「入馆后可能仍显示『取消预约』」）。
+     *
+     * 不是 issue 号：这个列表原样渲染在 What's New 弹窗的「已知问题」下面，
+     * 填 `"39"` 用户看到的就是一个光秃秃的「39」。也不要把这个版本**修好**的
+     * issue 写进来——那是 [items] 的事。
+     */
     val issues: List<String> = emptyList()
 )
 
@@ -26,12 +34,22 @@ object AppChangelog {
      * 新增版本只在最前面追加即可。
      */
     val ENTRIES: List<Pair<String, VersionChangelog>> = listOf(
+        "4.9.0" to VersionChangelog(
+            items = listOf(
+                "🖼️" to "屁岱能看图了，发课表截图、通知照片直接问",
+                "📚" to "屁岱可以搜仲英学辅资料，结果成卡片，点一下就下载",
+                "🧩" to "4×2 小部件改成今天／明天两栏，一屏看六节课；2×2 不再把「日程」裁成「日」",
+                "📅" to "修好开学前夕日程页误报「学期已结束」",
+                "🏛️" to "图书馆支持雁塔和创新港，可切换校区",
+                "💬" to "屁岱思考强度补上「低」档，换模型后不再自称上一个模型",
+                "🗓️" to "校历在假期里不再默认翻到几年前的学期"
+            )
+        ),
         "4.8.6" to VersionChangelog(
             items = listOf(
                 "📎" to "教务通知附件可以下载了",
                 "🌐" to "内置浏览器下载改由应用自己保存，不再被系统下载器打回验证码页"
-            ),
-            issues = listOf("39")
+            )
         ),
         "4.8.5" to VersionChangelog(
             items = listOf(

--- a/app/src/main/java/com/xjtu/toolbox/widget/ScheduleWidgetProvider.kt
+++ b/app/src/main/java/com/xjtu/toolbox/widget/ScheduleWidgetProvider.kt
@@ -34,6 +34,25 @@ internal data class WidgetCourse(
     val endSection: Int
 )
 
+/**
+ * 4x2「今天 / 明天」两栏要的数据。
+ *
+ * 和 [WidgetScheduleData] 分开：那个带着周次偏移、选中星期这些**浏览状态**，
+ * 是 2x2 的翻页交互要用的；4x2 改版后没有翻页，只认真实的今天和明天，
+ * 混用会让"明天"跟着用户在 2x2 上翻到的那一天跑。
+ */
+internal data class WidgetTwoDayData(
+    val dayNumber: String,
+    val monthText: String,
+    val dowText: String,
+    val weekText: String,
+    val today: List<WidgetCourse>,
+    val tomorrow: List<WidgetCourse>,
+    val todayEmptyText: String,
+    val tomorrowEmptyText: String,
+    val hasCache: Boolean,
+)
+
 internal data class WidgetScheduleData(
     val weekText: String,
     val dayText: String,
@@ -50,6 +69,9 @@ object ScheduleWidgetUpdater {
     const val ACTION_WEEK_NEXT = "com.xjtu.toolbox.widget.ACTION_SCHEDULE_WIDGET_WEEK_NEXT"
     const val ACTION_DAY_PREV = "com.xjtu.toolbox.widget.ACTION_SCHEDULE_WIDGET_DAY_PREV"
     const val ACTION_DAY_NEXT = "com.xjtu.toolbox.widget.ACTION_SCHEDULE_WIDGET_DAY_NEXT"
+
+    /** 适配器要取哪一天：0=今天，1=明天。只有 4x2 用。 */
+    const val EXTRA_DAY_OFFSET = "widget_day_offset"
 
     private const val PREFS_NAME = "schedule_widget_prefs"
     private const val KEY_WEEK_OFFSET = "week_offset"
@@ -119,15 +141,21 @@ object ScheduleWidgetUpdater {
         size: WidgetSize
     ) {
         if (appWidgetIds.isEmpty()) return
-        val data = loadScheduleData(context)
+        // 只有 2x2 用得上它，而它要读缓存、查 Room、拉节假日；4x2 走
+        // loadTwoDayData 自己那套，别为它白跑一遍。
+        val data = if (size == WidgetSize.SMALL) loadScheduleData(context) else null
         appWidgetIds.forEach { widgetId ->
             val views = when (size) {
-                WidgetSize.SMALL -> buildSmallViews(context, data, widgetId)
-                WidgetSize.LARGE -> buildLargeViews(context, data, widgetId)
+                WidgetSize.SMALL -> buildSmallViews(context, data!!, widgetId)
+                WidgetSize.LARGE -> buildLargeViews(context, widgetId)
             }
             appWidgetManager.updateAppWidget(widgetId, views)
         }
         appWidgetManager.notifyAppWidgetViewDataChanged(appWidgetIds, R.id.widget_course_list)
+        // 4x2 有第二个集合视图（明天那栏）。漏了它，明天的课会一直停在上次的数据上。
+        if (size == WidgetSize.LARGE) {
+            appWidgetManager.notifyAppWidgetViewDataChanged(appWidgetIds, R.id.widget_course_list_next)
+        }
     }
 
     private fun buildLaunchPendingIntent(context: Context, requestCode: Int): PendingIntent {
@@ -159,10 +187,21 @@ object ScheduleWidgetUpdater {
         )
     }
 
-    private fun buildCourseListAdapterIntent(context: Context, appWidgetId: Int, size: WidgetSize): Intent {
+    /**
+     * @param dayOffset 0=今天，1=明天。会进 Intent 的 data（[Intent.toUri] 把 extra 也编了进去），
+     *                  两栏因此拿到两个不同的 Intent —— 系统按 filterEquals 复用
+     *                  RemoteViewsFactory，data 一样的话两栏会共用同一个工厂、显示同一天。
+     */
+    private fun buildCourseListAdapterIntent(
+        context: Context,
+        appWidgetId: Int,
+        size: WidgetSize,
+        dayOffset: Int = 0,
+    ): Intent {
         return Intent(context, ScheduleWidgetRemoteViewsService::class.java).apply {
             putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
             putExtra("widget_size", size.name)
+            putExtra(EXTRA_DAY_OFFSET, dayOffset)
             data = Uri.parse(toUri(Intent.URI_INTENT_SCHEME))
         }
     }
@@ -243,24 +282,152 @@ object ScheduleWidgetUpdater {
         )
     }
 
-    private fun buildLargeViews(context: Context, data: WidgetScheduleData, appWidgetId: Int): RemoteViews {
-        return bindCommonViews(
-            context = context,
-            data = data,
-            appWidgetId = appWidgetId,
-            size = WidgetSize.LARGE,
-            providerClass = ScheduleWidget4x2Provider::class.java,
-            rootRequestCode = 1002,
-            weekRequestOffset = 2100,
-            dayRequestOffset = 2200,
-            listTemplateBase = 4000,
-            layoutRes = R.layout.widget_schedule_4x2
+    /**
+     * 4x2：今天 | 明天 两栏，没有任何翻页控件。
+     *
+     * 不走 [bindCommonViews]——那套是围绕 2x2 的浏览状态（周次偏移、选中星期）建的，
+     * 而这里要的恰恰是"不受浏览状态影响的真实今天"。
+     */
+    private fun buildLargeViews(context: Context, appWidgetId: Int): RemoteViews {
+        val data = loadTwoDayData(context)
+        val views = RemoteViews(context.packageName, R.layout.widget_schedule_4x2)
+        views.setTextViewText(R.id.widget_date_day, data.dayNumber)
+        views.setTextViewText(R.id.widget_date_month, data.monthText)
+        views.setTextViewText(R.id.widget_date_dow, data.dowText)
+        views.setTextViewText(R.id.widget_week, data.weekText)
+        views.setOnClickPendingIntent(R.id.widget_root, buildLaunchPendingIntent(context, 1002))
+
+        listOf(
+            Triple(R.id.widget_course_list, R.id.widget_empty, 0),
+            Triple(R.id.widget_course_list_next, R.id.widget_empty_next, 1),
+        ).forEach { (listId, emptyId, dayOffset) ->
+            views.setRemoteAdapter(
+                listId,
+                buildCourseListAdapterIntent(context, appWidgetId, WidgetSize.LARGE, dayOffset)
+            )
+            views.setEmptyView(listId, emptyId)
+            views.setPendingIntentTemplate(
+                listId,
+                buildLaunchPendingIntent(context, 4000 + dayOffset * 1000 + appWidgetId)
+            )
+        }
+
+        val todayEmpty = data.today.isEmpty()
+        val tomorrowEmpty = data.tomorrow.isEmpty()
+        views.setViewVisibility(R.id.widget_empty, if (todayEmpty) View.VISIBLE else View.GONE)
+        views.setViewVisibility(R.id.widget_empty_next, if (tomorrowEmpty) View.VISIBLE else View.GONE)
+        views.setTextViewText(R.id.widget_empty, data.todayEmptyText)
+        views.setTextViewText(R.id.widget_empty_next, data.tomorrowEmptyText)
+        return views
+    }
+
+    /**
+     * 今天和明天的课，外加左上角那个日期块。
+     *
+     * 明确**不读** [PREFS_NAME] 里的周次/星期偏移：那是 2x2 翻页留下的浏览状态，
+     * 4x2 要的是"现在"。
+     */
+    internal fun loadTwoDayData(context: Context): WidgetTwoDayData {
+        ensureAccountContext(context)
+        val today = LocalDate.now()
+        val tomorrow = today.plusDays(1)
+        val header = { d: LocalDate ->
+            Triple(
+                d.dayOfMonth.toString(),
+                "${d.monthValue}月",
+                "周${weekdayLabel(d.dayOfWeek.value)}",
+            )
+        }
+        val (dayNumber, monthText, dowText) = header(today)
+
+        val cache = DataCache(context)
+        val termCode = resolveTermCode(context, cache)
+            ?: return WidgetTwoDayData(
+                dayNumber, monthText, dowText, "",
+                today = emptyList(), tomorrow = emptyList(),
+                todayEmptyText = "暂无日程缓存\n请先打开日程页同步",
+                tomorrowEmptyText = "",
+                hasCache = false,
+            )
+
+        val startDate = readStartDate(cache, termCode)
+        val weekText = startDate
+            ?.let { com.xjtu.toolbox.schedule.TermWeeks.weekOf(it, today) }
+            ?.takeIf { it >= 1 }
+            ?.let { "第${it}周" }
+            .orEmpty()
+
+        return WidgetTwoDayData(
+            dayNumber = dayNumber,
+            monthText = monthText,
+            dowText = dowText,
+            weekText = weekText,
+            today = coursesOn(context, cache, termCode, startDate, today),
+            tomorrow = coursesOn(context, cache, termCode, startDate, tomorrow),
+            todayEmptyText = "今天没有课",
+            tomorrowEmptyText = "明天没有课",
+            hasCache = true,
         )
     }
 
-    internal fun loadScheduleData(context: Context): WidgetScheduleData {
-        // Widget 进程入口可能未经 MainActivity，AccountContext 未初始化；
-        // 从 AccountStore 恢复激活账号，保证 DataCache/Room 命名空间正确。
+    /** 某一天的课，按节次排序。节假日返回空。 */
+    private fun coursesOn(
+        context: Context,
+        cache: DataCache,
+        termCode: String,
+        startDate: LocalDate?,
+        date: LocalDate,
+    ): List<WidgetCourse> {
+        val holidays = runCatching {
+            runBlocking { com.xjtu.toolbox.schedule.HolidayApi.getHolidayDates(context) }
+        }.getOrDefault(emptyMap())
+        if (holidays.containsKey(date)) return emptyList()
+
+        val all = allCoursesOf(context, cache, termCode)
+        // 没有开学日期就算不出周次；这时按星期给出全部同星期的课，
+        // 总好过一片空白（用户至少能看出"周三大概有什么"）。
+        val week = startDate?.let { com.xjtu.toolbox.schedule.TermWeeks.weekOf(it, date) }
+        return all.asSequence()
+            .filter { it.dayOfWeek == date.dayOfWeek.value }
+            .filter { week == null || it.isInWeek(week) }
+            .sortedBy { it.startSection }
+            .map {
+                WidgetCourse(
+                    name = it.courseName,
+                    location = it.location,
+                    startSection = it.startSection,
+                    endSection = it.endSection,
+                )
+            }
+            .toList()
+    }
+
+    private fun allCoursesOf(context: Context, cache: DataCache, termCode: String): List<CourseItem> {
+        val apiCourses = ScheduleCache.readOptimizedCourses(cache, gson, termCode)
+            ?: ScheduleCache.readRawCourses(cache, gson, termCode)
+            ?: emptyList()
+        val customCourses = runCatching {
+            runBlocking {
+                AppDatabase.getInstance(context)
+                    .customCourseDao()
+                    .getByTerm(com.xjtu.toolbox.account.AccountContext.activeAccountId ?: "", termCode)
+                    .map { it.toCourseItem() }
+            }
+        }.getOrDefault(emptyList())
+        return apiCourses + customCourses
+    }
+
+    private fun readStartDate(cache: DataCache, termCode: String): LocalDate? {
+        val raw = cache.get("start_date_$termCode", Long.MAX_VALUE)
+        if (raw.isNullOrBlank()) return null
+        return runCatching { LocalDate.parse(gson.fromJson(raw, String::class.java)) }.getOrNull()
+    }
+
+    /**
+     * Widget 进程入口可能未经 MainActivity，AccountContext 未初始化；
+     * 从 AccountStore 恢复激活账号，保证 DataCache/Room 命名空间正确。
+     */
+    private fun ensureAccountContext(context: Context) {
         if (com.xjtu.toolbox.account.AccountContext.activeAccountId == null) {
             runCatching {
                 com.xjtu.toolbox.account.AccountStore(context).activeAccountId()?.let {
@@ -268,6 +435,10 @@ object ScheduleWidgetUpdater {
                 }
             }
         }
+    }
+
+    internal fun loadScheduleData(context: Context): WidgetScheduleData {
+        ensureAccountContext(context)
         val now = LocalTime.now()
         val nowDate = LocalDate.now()
         val todayDow = nowDate.dayOfWeek.value
@@ -310,8 +481,7 @@ object ScheduleWidgetUpdater {
         }
 
         val baseWeek = startDate?.let {
-            val days = java.time.temporal.ChronoUnit.DAYS.between(it, nowDate)
-            ((days / 7) + 1).toInt()
+            com.xjtu.toolbox.schedule.TermWeeks.weekOf(it, nowDate)
         }
 
         val maxWeek = allCourses.maxOfOrNull { it.weekBits.length }?.coerceAtLeast(1) ?: 20
@@ -345,7 +515,7 @@ object ScheduleWidgetUpdater {
         val shouldFilterByWeek = baseWeek != null || weekOffset != 0
 
         val selectedDate = if (startDate != null) {
-            startDate.plusDays(((effectiveWeek - 1) * 7L) + (selectedDayOfWeek - 1L))
+            com.xjtu.toolbox.schedule.TermWeeks.dateOf(startDate, effectiveWeek, selectedDayOfWeek)
         } else {
             val relativeWeekDelta = effectiveWeek - (displayBaseWeek ?: 1)
             nowDate.plusDays(relativeWeekDelta * 7L + (selectedDayOfWeek - todayDow).toLong())

--- a/app/src/main/java/com/xjtu/toolbox/widget/ScheduleWidgetRemoteViewsService.kt
+++ b/app/src/main/java/com/xjtu/toolbox/widget/ScheduleWidgetRemoteViewsService.kt
@@ -13,15 +13,20 @@ class ScheduleWidgetRemoteViewsService : RemoteViewsService() {
         val size = intent.getStringExtra("widget_size")
             ?.let { runCatching { WidgetSize.valueOf(it) }.getOrNull() }
             ?: WidgetSize.SMALL
-        return ScheduleWidgetCourseFactory(applicationContext, size)
+        // 4x2 有今天、明天两栏，各挂一个适配器，靠这个 extra 区分。
+        val dayOffset = intent.getIntExtra(ScheduleWidgetUpdater.EXTRA_DAY_OFFSET, 0)
+        return ScheduleWidgetCourseFactory(applicationContext, size, dayOffset)
     }
 }
 
 private class ScheduleWidgetCourseFactory(
     private val context: Context,
-    private val widgetSize: WidgetSize
+    private val widgetSize: WidgetSize,
+    /** 0=今天，1=明天。仅 [WidgetSize.LARGE] 使用；2x2 的"哪一天"由翻页状态决定。 */
+    private val dayOffset: Int = 0,
 ) : RemoteViewsService.RemoteViewsFactory {
 
+    /** 2x2 的整块浅色底。 */
     private val toneBackgrounds = intArrayOf(
         R.drawable.bg_schedule_course_item,
         R.drawable.bg_schedule_course_item_2,
@@ -31,15 +36,28 @@ private class ScheduleWidgetCourseFactory(
         R.drawable.bg_schedule_course_item_6
     )
 
+    /** 4x2 的左侧色条。和上面一一对应，同一门课两种尺寸下颜色一致。 */
+    private val accentBars = intArrayOf(
+        R.drawable.bg_widget_accent_1,
+        R.drawable.bg_widget_accent_2,
+        R.drawable.bg_widget_accent_3,
+        R.drawable.bg_widget_accent_4,
+        R.drawable.bg_widget_accent_5,
+        R.drawable.bg_widget_accent_6
+    )
+
     private var courses: List<WidgetCourse> = emptyList()
 
     override fun onCreate() = Unit
 
     override fun onDataSetChanged() {
-        val allCourses = ScheduleWidgetUpdater.loadScheduleData(context).courses
         courses = when (widgetSize) {
-            WidgetSize.SMALL -> allCourses.take(2)
-            WidgetSize.LARGE -> allCourses.take(4)
+            // 2x2 跟随翻页状态，显示"用户正在看的那天"。
+            WidgetSize.SMALL -> ScheduleWidgetUpdater.loadScheduleData(context).courses.take(3)
+            // 4x2 是今天 / 明天两栏，每栏 3 条正好填满，与 issue #41 参考图一致。
+            WidgetSize.LARGE -> ScheduleWidgetUpdater.loadTwoDayData(context)
+                .let { if (dayOffset == 0) it.today else it.tomorrow }
+                .take(3)
         }
     }
 
@@ -52,23 +70,40 @@ private class ScheduleWidgetCourseFactory(
     override fun getViewAt(position: Int): RemoteViews? {
         if (position !in courses.indices) return null
         val course = courses[position]
-        val views = RemoteViews(context.packageName, R.layout.widget_schedule_course_item)
+        val itemLayout = when (widgetSize) {
+            WidgetSize.SMALL -> R.layout.widget_schedule_course_item
+            WidgetSize.LARGE -> R.layout.widget_schedule_course_accent_item
+        }
+        val views = RemoteViews(context.packageName, itemLayout)
         val toneIndex = ((course.name + course.location + course.startSection + course.endSection)
             .hashCode()
             .let { if (it == Int.MIN_VALUE) 0 else abs(it) }) % toneBackgrounds.size
-        views.setInt(
-            R.id.widget_course_item_root,
-            "setBackgroundResource",
-            toneBackgrounds[toneIndex]
-        )
-        views.setTextViewText(
-            R.id.widget_course_time,
+        val timeRange =
             "${XjtuTime.getClassStartStr(course.startSection)}-${XjtuTime.getClassEndStr(course.endSection)}"
-        )
-        views.setTextViewText(
-            R.id.widget_course_desc,
-            "${course.name} · ${course.location.ifBlank { "地点待定" }}"
-        )
+        val place = course.location.ifBlank { "地点待定" }
+        when (widgetSize) {
+            // 2x2：整块浅色底，一行放得下「课名 · 地点」，时间单独一行。
+            WidgetSize.SMALL -> {
+                views.setInt(
+                    R.id.widget_course_item_root,
+                    "setBackgroundResource",
+                    toneBackgrounds[toneIndex]
+                )
+                views.setTextViewText(R.id.widget_course_desc, "${course.name} · $place")
+                views.setTextViewText(R.id.widget_course_time, timeRange)
+            }
+            // 4x2：每栏只有半个部件宽，色块底会把字挤没，改成左侧色条；
+            // 课名独占一行，时间和地点合并到第二行。
+            WidgetSize.LARGE -> {
+                views.setInt(
+                    R.id.widget_course_accent,
+                    "setBackgroundResource",
+                    accentBars[toneIndex]
+                )
+                views.setTextViewText(R.id.widget_course_desc, course.name)
+                views.setTextViewText(R.id.widget_course_time, "$timeRange $place")
+            }
+        }
         views.setOnClickFillInIntent(R.id.widget_course_item_root, Intent())
         return views
     }

--- a/app/src/main/java/com/xjtu/toolbox/zyxf/ZyxfApi.kt
+++ b/app/src/main/java/com/xjtu/toolbox/zyxf/ZyxfApi.kt
@@ -1,0 +1,207 @@
+package com.xjtu.toolbox.zyxf
+
+import android.util.Log
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONArray
+import org.json.JSONObject
+import java.util.concurrent.TimeUnit
+
+/**
+ * 仲英学辅资料站（zyxf.top）的只读接口。
+ *
+ * 后端开源在 [Guochaoo/zyxf](https://github.com/Guochaoo/zyxf)，`/api` 下检索、目录树、
+ * 目录内容、取文件直链这几条都是**匿名可读**的（写操作才要管理员），所以这里不带任何
+ * 凭据，也不碰 [ZyxfDownloader] 那条要 WebView cookie 的路径。
+ *
+ * 只做"查"和"读"两件事：
+ * - 查：[search] / [listFolder]，把资料站当成一棵可检索的目录树；
+ * - 读：[readText] 只认纯文本（txt/csv/md）。PDF、Office 走服务端的 WebOffice 预览，
+ *   在 App 里解析它们要拖进一整套文档解析库，投入和收益不成比例——
+ *   这类文件就给出直链，让用户去资料页看或下载。
+ */
+object ZyxfApi {
+
+    private const val TAG = "ZyxfApi"
+    const val SITE = "https://zyxf.top"
+    private const val API = "$SITE/api"
+
+    /** 能直接读成文字的扩展名。其余一律只给链接。 */
+    private val TEXT_EXTS = setOf("txt", "csv", "md", "markdown", "tex", "json", "log")
+
+    /** 读文本的字节上限。资料站单个 txt 可以很大，整份灌进对话只会把上下文撑爆。 */
+    private const val MAX_TEXT_BYTES = 256 * 1024
+
+    private val client: OkHttpClient by lazy {
+        OkHttpClient.Builder()
+            .connectTimeout(15, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .build()
+    }
+
+    data class Entry(
+        val id: Int,
+        val name: String,
+        /** 目录路径，如 `高等数学/历年卷`；检索结果才有，浏览目录时为空。 */
+        val path: String = "",
+        val isFolder: Boolean,
+        val sizeBytes: Long = 0,
+        val ext: String = "",
+    ) {
+        val extNormalized: String get() = ext.lowercase().removePrefix(".")
+        val readable: Boolean get() = !isFolder && extNormalized in TEXT_EXTS
+
+        /** 人读的大小。目录没有 size，返回空串。 */
+        val sizeText: String
+            get() = when {
+                isFolder || sizeBytes <= 0 -> ""
+                sizeBytes < 1024 -> "${sizeBytes}B"
+                sizeBytes < 1024 * 1024 -> "${sizeBytes / 1024}KB"
+                else -> String.format("%.1fMB", sizeBytes / 1024.0 / 1024.0)
+            }
+    }
+
+    data class SearchResult(
+        val entries: List<Entry>,
+        /** 服务端截断了结果。命中太多时要提示用户把关键词写细一点。 */
+        val truncated: Boolean,
+    )
+
+    data class FileLink(
+        val url: String,
+        val name: String,
+        val ext: String,
+        val mimeType: String,
+        val sizeBytes: Long,
+    )
+
+    private fun get(url: String): String {
+        val req = Request.Builder().url(url)
+            .header("Accept", "application/json")
+            .header("Referer", "$SITE/")
+            .get()
+            .build()
+        client.newCall(req).execute().use { resp ->
+            val body = resp.body?.string().orEmpty()
+            if (!resp.isSuccessful) {
+                // 服务端错误体是 {"error": "..."}，把它原样带出去比"HTTP 400"有用得多。
+                val msg = runCatching { JSONObject(body).optString("error") }.getOrNull()
+                throw RuntimeException(msg?.takeIf { it.isNotBlank() } ?: "HTTP ${resp.code}")
+            }
+            return body
+        }
+    }
+
+    private fun folderOf(o: JSONObject) = Entry(
+        id = o.optInt("id"),
+        name = o.optString("name"),
+        path = o.optString("folder_path", ""),
+        isFolder = true,
+    )
+
+    private fun fileOf(o: JSONObject) = Entry(
+        id = o.optInt("id"),
+        name = o.optString("name"),
+        path = o.optString("folder_path", ""),
+        isFolder = false,
+        sizeBytes = o.optLong("size"),
+        ext = o.optString("ext", ""),
+    )
+
+    private fun JSONArray?.mapObjects(block: (JSONObject) -> Entry): List<Entry> {
+        val arr = this ?: return emptyList()
+        return (0 until arr.length()).mapNotNull { i -> arr.optJSONObject(i)?.let(block) }
+    }
+
+    /** 全站检索。目录排在文件前，与网页端一致。 */
+    fun search(keyword: String): SearchResult {
+        val q = java.net.URLEncoder.encode(keyword.trim(), "UTF-8")
+        val json = JSONObject(get("$API/search?q=$q"))
+        return SearchResult(
+            entries = json.optJSONArray("folders").mapObjects(::folderOf) +
+                json.optJSONArray("files").mapObjects(::fileOf),
+            truncated = json.optBoolean("truncated", false),
+        )
+    }
+
+    /**
+     * 列出一个目录。
+     *
+     * @param folderId 0 表示根目录（后端就是这么约定的，不是"缺省值"）
+     */
+    fun listFolder(folderId: Int = 0): List<Entry> {
+        val json = JSONObject(get("$API/folders/$folderId/contents"))
+        return json.optJSONArray("folders").mapObjects(::folderOf) +
+            json.optJSONArray("files").mapObjects(::fileOf)
+    }
+
+    /** 面包屑，用来告诉用户这份资料在哪个目录下。 */
+    fun breadcrumb(folderId: Int): String = runCatching {
+        val arr = JSONObject(get("$API/folders/$folderId/contents")).optJSONArray("breadcrumb")
+        (0 until (arr?.length() ?: 0))
+            .mapNotNull { arr?.optJSONObject(it)?.optString("name") }
+            .filter { it.isNotBlank() }
+            .joinToString("/")
+    }.getOrDefault("")
+
+    /**
+     * 取文件的临时直链。
+     *
+     * 服务端签的是 30 分钟有效的 OSS 链接，并且**按 IP 限流**（每分钟 60 次、每小时 240 次），
+     * 所以别拿它当稳定地址缓存起来，也别在循环里连着要。
+     */
+    fun fileLink(fileId: Int, forDownload: Boolean = false): FileLink {
+        val json = JSONObject(get("$API/files/$fileId/url" + if (forDownload) "?download=1" else ""))
+        return FileLink(
+            url = json.optString("url"),
+            name = json.optString("name"),
+            ext = json.optString("ext"),
+            mimeType = json.optString("mime_type", "application/octet-stream"),
+            sizeBytes = json.optLong("size"),
+        )
+    }
+
+    /**
+     * 下载一份资料到公共下载目录，返回落盘的文件名；失败返回 null。
+     *
+     * 走 `download=1` 取链：服务端会给 OSS 加 `attachment` 头并记一次下载量，
+     * 和网页端点下载按钮是同一条路径——不绕开站点的统计。
+     *
+     * 复用 [ZyxfDownloader]，所以文件会和成绩单、思源课件落在同一个目录、同一份下载记录里。
+     * 签名链自带鉴权，不需要 UA 和 cookie。
+     */
+    fun download(context: android.content.Context, fileId: Int): String? {
+        val link = runCatching { fileLink(fileId, forDownload = true) }.getOrNull() ?: return null
+        if (link.url.isBlank()) return null
+        return ZyxfDownloader.download(
+            context = context,
+            url = link.url,
+            fallbackName = link.name,
+            userAgent = null,
+            cookie = null,
+            referer = null,
+        )
+    }
+
+    /**
+     * 把纯文本资料读成字符串，最多 [MAX_TEXT_BYTES]。
+     *
+     * 非文本格式返回 null——调用方该给链接，而不是把二进制硬解成乱码丢给模型。
+     */
+    fun readText(entry: Entry): String? {
+        if (!entry.readable) return null
+        val link = runCatching { fileLink(entry.id) }.getOrNull() ?: return null
+        val req = Request.Builder().url(link.url).get().build()
+        return runCatching {
+            client.newCall(req).execute().use { resp ->
+                if (!resp.isSuccessful) return null
+                val bytes = resp.body?.source()?.let { source ->
+                    source.readByteArray(
+                        minOf(MAX_TEXT_BYTES.toLong(), resp.body?.contentLength()?.takeIf { it > 0 } ?: MAX_TEXT_BYTES.toLong())
+                    )
+                } ?: return null
+                bytes.toString(Charsets.UTF_8)
+            }
+        }.onFailure { Log.w(TAG, "readText failed: ${entry.name}", it) }.getOrNull()
+    }
+}

--- a/app/src/main/res/drawable/bg_widget_accent_1.xml
+++ b/app/src/main/res/drawable/bg_widget_accent_1.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <corners android:radius="2dp" />
+    <solid android:color="@color/widget_course_accent_1" />
+</shape>

--- a/app/src/main/res/drawable/bg_widget_accent_2.xml
+++ b/app/src/main/res/drawable/bg_widget_accent_2.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <corners android:radius="2dp" />
+    <solid android:color="@color/widget_course_accent_2" />
+</shape>

--- a/app/src/main/res/drawable/bg_widget_accent_3.xml
+++ b/app/src/main/res/drawable/bg_widget_accent_3.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <corners android:radius="2dp" />
+    <solid android:color="@color/widget_course_accent_3" />
+</shape>

--- a/app/src/main/res/drawable/bg_widget_accent_4.xml
+++ b/app/src/main/res/drawable/bg_widget_accent_4.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <corners android:radius="2dp" />
+    <solid android:color="@color/widget_course_accent_4" />
+</shape>

--- a/app/src/main/res/drawable/bg_widget_accent_5.xml
+++ b/app/src/main/res/drawable/bg_widget_accent_5.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <corners android:radius="2dp" />
+    <solid android:color="@color/widget_course_accent_5" />
+</shape>

--- a/app/src/main/res/drawable/bg_widget_accent_6.xml
+++ b/app/src/main/res/drawable/bg_widget_accent_6.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <corners android:radius="2dp" />
+    <solid android:color="@color/widget_course_accent_6" />
+</shape>

--- a/app/src/main/res/layout/widget_schedule_2x2.xml
+++ b/app/src/main/res/layout/widget_schedule_2x2.xml
@@ -1,11 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  2x2 日程小部件。
+
+  这一版的取舍：2x2 大约只有 110~150dp 见方，标题行原来塞了「日程 + ‹ + 周次 + ›」四件，
+  固定宽度就吃掉近 90dp，留给标题的空间不够显示两个汉字——于是"日程"被裁成"日"。
+
+  所以：
+  - **周次前后翻页按钮在这里隐藏**。左右翻天的按钮本来就会跨周滚（见
+    `adjustSelectedDayOfWeek`），2x2 上多一对周按钮纯属重复。id 保留，`bindCommonViews`
+    照样往上挂 PendingIntent，不用为小尺寸分叉。
+  - **「更新 HH:mm」隐藏**。9sp 的时间戳是典型的无效信息占位。
+  这两样让出来的空间全给课程列表。
+-->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/widget_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@drawable/bg_schedule_widget"
     android:orientation="vertical"
-    android:padding="10dp">
+    android:padding="8dp">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -15,61 +28,36 @@
 
         <TextView
             android:id="@+id/widget_title"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
             android:maxLines="1"
             android:textColor="@color/widget_on_surface"
-            android:textSize="14sp"
+            android:textSize="13sp"
             android:textStyle="bold" />
 
         <TextView
             android:id="@+id/widget_week_prev"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:background="@drawable/bg_widget_action_pill"
-            android:gravity="center"
-            android:text="‹"
-            android:textColor="@color/widget_on_surface_secondary"
-            android:textSize="12sp"
-            android:textStyle="bold" />
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:visibility="gone" />
 
         <TextView
             android:id="@+id/widget_week"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginLeft="4dp"
-            android:layout_marginRight="4dp"
-            android:background="@drawable/bg_widget_chip"
-            android:paddingLeft="6dp"
-            android:paddingRight="6dp"
-            android:paddingTop="2dp"
-            android:paddingBottom="2dp"
+            android:layout_weight="1"
+            android:layout_marginLeft="6dp"
+            android:gravity="end"
             android:maxLines="1"
             android:textColor="@color/widget_on_surface_secondary"
             android:textSize="11sp" />
 
         <TextView
             android:id="@+id/widget_week_next"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:background="@drawable/bg_widget_action_pill"
-            android:gravity="center"
-            android:text="›"
-            android:textColor="@color/widget_on_surface_secondary"
-            android:textSize="12sp"
-            android:textStyle="bold" />
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:visibility="gone" />
     </LinearLayout>
-
-    <TextView
-        android:id="@+id/widget_status"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="4dp"
-        android:ellipsize="end"
-        android:maxLines="1"
-        android:textColor="@color/widget_on_surface_secondary"
-        android:textSize="11sp" />
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -80,8 +68,8 @@
 
         <TextView
             android:id="@+id/widget_day_prev"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
+            android:layout_width="22dp"
+            android:layout_height="22dp"
             android:background="@drawable/bg_widget_action_pill"
             android:gravity="center"
             android:text="‹"
@@ -94,20 +82,23 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:gravity="center"
+            android:layout_marginLeft="4dp"
+            android:layout_marginRight="4dp"
             android:background="@drawable/bg_widget_chip"
-            android:paddingLeft="6dp"
-            android:paddingRight="6dp"
+            android:gravity="center"
+            android:paddingLeft="4dp"
+            android:paddingRight="4dp"
             android:paddingTop="2dp"
             android:paddingBottom="2dp"
             android:maxLines="1"
+            android:ellipsize="end"
             android:textColor="@color/widget_on_surface"
             android:textSize="11sp" />
 
         <TextView
             android:id="@+id/widget_day_next"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
+            android:layout_width="22dp"
+            android:layout_height="22dp"
             android:background="@drawable/bg_widget_action_pill"
             android:gravity="center"
             android:text="›"
@@ -116,16 +107,26 @@
             android:textStyle="bold" />
     </LinearLayout>
 
+    <TextView
+        android:id="@+id/widget_status"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="3dp"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:textColor="@color/widget_on_surface_secondary"
+        android:textSize="10sp" />
+
     <ListView
         android:id="@+id/widget_course_list"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_marginTop="6dp"
+        android:layout_marginTop="4dp"
         android:layout_weight="1"
         android:divider="@android:color/transparent"
-        android:dividerHeight="6dp"
+        android:dividerHeight="4dp"
         android:fastScrollEnabled="false"
-        android:scrollbars="vertical" />
+        android:scrollbars="none" />
 
     <TextView
         android:id="@+id/widget_empty"
@@ -134,16 +135,14 @@
         android:layout_weight="1"
         android:gravity="center"
         android:textColor="@color/widget_on_surface_secondary"
-        android:textSize="12sp"
+        android:textSize="11sp"
         android:visibility="gone" />
 
+    <!-- 更新时间：2x2 放不下，隐藏但保留 id，绑定逻辑不分叉。 -->
     <TextView
         android:id="@+id/widget_update"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="end"
-        android:maxLines="1"
-        android:textColor="@color/widget_on_surface_secondary"
-        android:textSize="9sp" />
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:visibility="gone" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/widget_schedule_4x2.xml
+++ b/app/src/main/res/layout/widget_schedule_4x2.xml
@@ -1,149 +1,154 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  4x2 日程小部件 —— 「今天 | 明天」两栏。
+
+  改版前这个文件和 2x2 逐字节相同：竖排 ListView + 四行固定头部（标题、状态、周次翻页、
+  日期翻页、更新时间）。4x2 的高度和 2x2 一样，头部就吃掉近 90dp，一屏只剩一条课的位置，
+  而宽出来的两格完全没用上——issue #41 里那张截图，三节课只显示了一节。
+
+  这一版照 issue 里给的参考（校园集市）重做：
+  - **左栏今天、右栏明天**，一眼看完两天，正好 3 + 3 节；
+  - 左上角一个大日期块代替「日程」标题；
+  - **去掉全部翻页按钮和「更新 HH:mm」**。4x2 的价值是扫一眼就知道接下来干嘛，
+    翻周翻天是"操作"，留在 2x2 和应用里；把那几个 pill 去掉才换得出这两栏。
+
+  两个 ListView 各自挂适配器（day_offset 0 / 1），刷新时两个都要
+  notifyAppWidgetViewDataChanged，只刷一个会让明天那栏停在旧数据上。
+-->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/widget_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@drawable/bg_schedule_widget"
-    android:orientation="vertical"
+    android:orientation="horizontal"
+    android:baselineAligned="false"
     android:padding="10dp">
 
+    <!-- ── 今天 ── -->
     <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center_vertical"
-        android:orientation="horizontal">
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
+        android:orientation="vertical">
 
-        <TextView
-            android:id="@+id/widget_title"
-            android:layout_width="0dp"
+        <LinearLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:baselineAligned="false"
+            android:gravity="center_vertical">
+
+            <TextView
+                android:id="@+id/widget_date_day"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:includeFontPadding="false"
+                android:maxLines="1"
+                android:textColor="@color/widget_on_surface"
+                android:textSize="26sp"
+                android:textStyle="bold" />
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:layout_marginStart="6dp"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/widget_date_month"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:includeFontPadding="false"
+                    android:maxLines="1"
+                    android:textColor="@color/widget_on_surface_secondary"
+                    android:textSize="11sp" />
+
+                <TextView
+                    android:id="@+id/widget_date_dow"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:includeFontPadding="false"
+                    android:maxLines="1"
+                    android:textColor="@color/widget_on_surface_secondary"
+                    android:textSize="11sp" />
+            </LinearLayout>
+
+            <TextView
+                android:id="@+id/widget_week"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:maxLines="1"
+                android:textColor="@color/widget_on_surface_secondary"
+                android:textSize="10sp" />
+        </LinearLayout>
+
+        <ListView
+            android:id="@+id/widget_course_list"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginTop="6dp"
             android:layout_weight="1"
-            android:maxLines="1"
-            android:textColor="@color/widget_on_surface"
-            android:textSize="14sp"
-            android:textStyle="bold" />
+            android:divider="@android:color/transparent"
+            android:dividerHeight="7dp"
+            android:fastScrollEnabled="false"
+            android:scrollbars="none" />
 
         <TextView
-            android:id="@+id/widget_week_prev"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:background="@drawable/bg_widget_action_pill"
-            android:gravity="center"
-            android:text="‹"
+            android:id="@+id/widget_empty"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:gravity="center_vertical"
+            android:maxLines="2"
+            android:ellipsize="end"
             android:textColor="@color/widget_on_surface_secondary"
-            android:textSize="12sp"
-            android:textStyle="bold" />
-
-        <TextView
-            android:id="@+id/widget_week"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="4dp"
-            android:layout_marginRight="4dp"
-            android:background="@drawable/bg_widget_chip"
-            android:paddingLeft="6dp"
-            android:paddingRight="6dp"
-            android:paddingTop="2dp"
-            android:paddingBottom="2dp"
-            android:maxLines="1"
-            android:textColor="@color/widget_on_surface_secondary"
-            android:textSize="11sp" />
-
-        <TextView
-            android:id="@+id/widget_week_next"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:background="@drawable/bg_widget_action_pill"
-            android:gravity="center"
-            android:text="›"
-            android:textColor="@color/widget_on_surface_secondary"
-            android:textSize="12sp"
-            android:textStyle="bold" />
+            android:textSize="11sp"
+            android:visibility="gone" />
     </LinearLayout>
 
-    <TextView
-        android:id="@+id/widget_status"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="4dp"
-        android:ellipsize="end"
-        android:maxLines="1"
-        android:textColor="@color/widget_on_surface_secondary"
-        android:textSize="11sp" />
-
+    <!-- ── 明天 ── -->
     <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="4dp"
-        android:gravity="center_vertical"
-        android:orientation="horizontal">
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
+        android:layout_marginStart="12dp"
+        android:orientation="vertical">
 
         <TextView
-            android:id="@+id/widget_day_prev"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:background="@drawable/bg_widget_action_pill"
-            android:gravity="center"
-            android:text="‹"
-            android:textColor="@color/widget_on_surface_secondary"
-            android:textSize="12sp"
-            android:textStyle="bold" />
-
-        <TextView
-            android:id="@+id/widget_day_text"
-            android:layout_width="0dp"
+            android:id="@+id/widget_title_next"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:gravity="center"
-            android:background="@drawable/bg_widget_chip"
-            android:paddingLeft="6dp"
-            android:paddingRight="6dp"
-            android:paddingTop="2dp"
-            android:paddingBottom="2dp"
+            android:includeFontPadding="false"
             android:maxLines="1"
-            android:textColor="@color/widget_on_surface"
-            android:textSize="11sp" />
+            android:paddingTop="4dp"
+            android:paddingBottom="4dp"
+            android:text="明天"
+            android:textColor="@color/widget_on_surface_secondary"
+            android:textSize="14sp" />
+
+        <ListView
+            android:id="@+id/widget_course_list_next"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginTop="6dp"
+            android:layout_weight="1"
+            android:divider="@android:color/transparent"
+            android:dividerHeight="7dp"
+            android:fastScrollEnabled="false"
+            android:scrollbars="none" />
 
         <TextView
-            android:id="@+id/widget_day_next"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:background="@drawable/bg_widget_action_pill"
-            android:gravity="center"
-            android:text="›"
+            android:id="@+id/widget_empty_next"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:gravity="center_vertical"
+            android:maxLines="2"
+            android:ellipsize="end"
             android:textColor="@color/widget_on_surface_secondary"
-            android:textSize="12sp"
-            android:textStyle="bold" />
+            android:textSize="11sp"
+            android:visibility="gone" />
     </LinearLayout>
-
-    <ListView
-        android:id="@+id/widget_course_list"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_marginTop="6dp"
-        android:layout_weight="1"
-        android:divider="@android:color/transparent"
-        android:dividerHeight="6dp"
-        android:fastScrollEnabled="false"
-        android:scrollbars="vertical" />
-
-    <TextView
-        android:id="@+id/widget_empty"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1"
-        android:gravity="center"
-        android:textColor="@color/widget_on_surface_secondary"
-        android:textSize="12sp"
-        android:visibility="gone" />
-
-    <TextView
-        android:id="@+id/widget_update"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="end"
-        android:maxLines="1"
-        android:textColor="@color/widget_on_surface_secondary"
-        android:textSize="9sp" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/widget_schedule_course_accent_item.xml
+++ b/app/src/main/res/layout/widget_schedule_course_accent_item.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  4x2「今天 / 明天」两栏里的单条课程。
+
+  和 2x2 那版的整块浅色底不同，这里是**左侧色条 + 两行文字**：色块底会把本来就只有
+  半栏宽的格子挤得更窄，而色条只占 3dp，剩下的宽度全留给课名和地点。
+  样式对齐 issue #41 里给的参考（校园集市）。
+
+  色条用 TextView 而不是 View：RemoteViews 只接受固定的一组控件类型，View 不在其中。
+-->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_course_item_root"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:baselineAligned="false">
+
+    <TextView
+        android:id="@+id/widget_course_accent"
+        android:layout_width="3dp"
+        android:layout_height="match_parent"
+        android:layout_marginTop="1dp"
+        android:layout_marginBottom="1dp"
+        android:background="@drawable/bg_widget_accent_1" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="7dp"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/widget_course_desc"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textColor="@color/widget_on_surface"
+            android:textSize="13sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/widget_course_time"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textColor="@color/widget_on_surface_secondary"
+            android:textSize="11sp" />
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/widget_schedule_course_item.xml
+++ b/app/src/main/res/layout/widget_schedule_course_item.xml
@@ -1,14 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  2x2 竖排列表的单条课程。比原来紧一圈（padding 8→6，行距 2→1），
+  一屏从 2 条变 3 条——小部件的空间要花在课上，不是花在留白上。
+-->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/widget_course_item_root"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@drawable/bg_schedule_course_item"
     android:orientation="vertical"
-    android:paddingLeft="10dp"
-    android:paddingRight="10dp"
-    android:paddingTop="8dp"
-    android:paddingBottom="8dp">
+    android:paddingLeft="8dp"
+    android:paddingRight="8dp"
+    android:paddingTop="6dp"
+    android:paddingBottom="6dp">
 
     <TextView
         android:id="@+id/widget_course_desc"
@@ -24,11 +28,10 @@
         android:id="@+id/widget_course_time"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="2dp"
+        android:layout_marginTop="1dp"
         android:ellipsize="end"
         android:maxLines="1"
         android:textColor="@color/widget_on_surface_secondary"
         android:textSize="10sp" />
 
 </LinearLayout>
-

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -12,4 +12,11 @@
     <color name="widget_course_tone_4">#FF3B2B4A</color>
     <color name="widget_course_tone_5">#FF23424A</color>
     <color name="widget_course_tone_6">#FF4A2B2B</color>
+
+    <color name="widget_course_accent_1">#FF8AA5FF</color>
+    <color name="widget_course_accent_2">#FF5FD49B</color>
+    <color name="widget_course_accent_3">#FFF5B963</color>
+    <color name="widget_course_accent_4">#FFBE95FF</color>
+    <color name="widget_course_accent_5">#FF5FCBD8</color>
+    <color name="widget_course_accent_6">#FFFF8A8A</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -27,4 +27,11 @@
     <color name="shortcut_campus_card_bg">#FF2E7D32</color>
     <color name="shortcut_empty_room_bg">#FF283593</color>
     <color name="shortcut_payment_bg">#FF00796B</color>
+
+    <color name="widget_course_accent_1">#FF6C8CFF</color>
+    <color name="widget_course_accent_2">#FF3FBF7F</color>
+    <color name="widget_course_accent_3">#FFF0A23C</color>
+    <color name="widget_course_accent_4">#FFA76EFF</color>
+    <color name="widget_course_accent_5">#FF35B6C4</color>
+    <color name="widget_course_accent_6">#FFEF6B6B</color>
 </resources>

--- a/app/src/test/java/com/xjtu/toolbox/schedule/TermWeeksTest.kt
+++ b/app/src/test/java/com/xjtu/toolbox/schedule/TermWeeksTest.kt
@@ -1,0 +1,128 @@
+package com.xjtu.toolbox.schedule
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import java.time.LocalDate
+
+class TermWeeksTest {
+
+    /** 2026 秋季学期，开学日期是周一。 */
+    private val start = LocalDate.of(2026, 8, 31)
+
+    @Test
+    fun `开学当天是第一周`() {
+        assertEquals(1, TermWeeks.weekOf(start, start))
+    }
+
+    @Test
+    fun `开学那周周日仍是第一周`() {
+        assertEquals(1, TermWeeks.weekOf(start, LocalDate.of(2026, 9, 6)))
+    }
+
+    @Test
+    fun `下一个周一进入第二周`() {
+        assertEquals(2, TermWeeks.weekOf(start, LocalDate.of(2026, 9, 7)))
+    }
+
+    /**
+     * issue #44 的第一层：开学前几天。
+     *
+     * 旧写法 `(daysBetween / 7) + 1` 在 Kotlin 里对负数向零截断，-5/7 得 0，
+     * 于是开学前五天被算成"第 1 周"。这里必须是 0（上一周）。
+     */
+    @Test
+    fun `开学前几天是第零周而不是第一周`() {
+        assertEquals(0, TermWeeks.weekOf(start, LocalDate.of(2026, 8, 26)))
+        assertEquals(0, TermWeeks.weekOf(start, LocalDate.of(2026, 8, 30)))
+        assertEquals(-1, TermWeeks.weekOf(start, LocalDate.of(2026, 8, 19)))
+    }
+
+    @Test
+    fun `开学日期落在周中时锚到那周的周一`() {
+        // 教务给的是周三，第 1 周仍应从这一周的周一算起。
+        val midWeekStart = LocalDate.of(2026, 9, 2)
+        assertEquals(1, TermWeeks.weekOf(midWeekStart, LocalDate.of(2026, 8, 31)))
+        assertEquals(1, TermWeeks.weekOf(midWeekStart, LocalDate.of(2026, 9, 6)))
+        assertEquals(2, TermWeeks.weekOf(midWeekStart, LocalDate.of(2026, 9, 7)))
+    }
+
+    /**
+     * issue #44 的第二层：课表还没拉到时 `totalWeeks` 是 0。
+     *
+     * 0 是"不知道"，不是"零周"。旧逻辑直接比 `rawWeek > totalWeeks`，
+     * 任何周次都大于 0，于是报"学期已结束"——这就是开学前夕那条 bug 的样子。
+     */
+    @Test
+    fun `课表未加载时不得判为学期已结束`() {
+        val status = TermWeeks.statusOf(start, totalWeeks = 0, today = LocalDate.of(2026, 9, 3))
+        assertEquals(TermWeeks.Status.Unknown(1), status)
+        assertNull(TermWeeks.noteOf(status))
+        assertEquals(1, TermWeeks.displayWeekOf(status))
+    }
+
+    @Test
+    fun `开学前夕且课表未加载时提示距开学`() {
+        val status = TermWeeks.statusOf(start, totalWeeks = 0, today = LocalDate.of(2026, 8, 26))
+        assertEquals(TermWeeks.Status.BeforeTerm(1), status)
+        assertEquals("距开学还有 1 周", TermWeeks.noteOf(status))
+    }
+
+    @Test
+    fun `超出总周数才算学期结束`() {
+        val lastWeek = LocalDate.of(2026, 12, 21)   // 第 17 周
+        assertEquals(17, TermWeeks.weekOf(start, lastWeek))
+        assertEquals(
+            TermWeeks.Status.InTerm(17),
+            TermWeeks.statusOf(start, totalWeeks = 18, today = lastWeek)
+        )
+        assertEquals(
+            TermWeeks.Status.AfterTerm,
+            TermWeeks.statusOf(start, totalWeeks = 16, today = lastWeek)
+        )
+    }
+
+    @Test
+    fun `学期已开始但第一门课在后面时提示尚未开课`() {
+        val status = TermWeeks.statusOf(
+            start, totalWeeks = 18, firstTeachWeek = 3, today = LocalDate.of(2026, 9, 3)
+        )
+        assertEquals(TermWeeks.Status.NotStartedYet(week = 1, firstTeachWeek = 3), status)
+        assertEquals("尚未开课 · 第3周开始上课", TermWeeks.noteOf(status))
+        assertEquals(3, TermWeeks.displayWeekOf(status))
+    }
+
+    @Test
+    fun `周次与日期互为逆运算`() {
+        listOf(1, 5, 18).forEach { week ->
+            (1..7).forEach { dow ->
+                val date = TermWeeks.dateOf(start, week, dow)
+                assertEquals(week, TermWeeks.weekOf(start, date))
+                assertEquals(dow, date.dayOfWeek.value)
+            }
+        }
+    }
+
+    @Test
+    fun `第一门课的周次取最小的置位`() {
+        val courses = listOf(
+            courseWithBits("0001100000"),
+            courseWithBits("0100000000"),
+        )
+        assertEquals(2, TermWeeks.firstTeachWeekOf(courses))
+        assertNull(TermWeeks.firstTeachWeekOf(emptyList()))
+        assertNull(TermWeeks.firstTeachWeekOf(listOf(courseWithBits("0000"))))
+    }
+
+    private fun courseWithBits(bits: String) = CourseItem(
+        courseName = "测试课",
+        teacher = "",
+        location = "",
+        weekBits = bits,
+        dayOfWeek = 1,
+        startSection = 1,
+        endSection = 2,
+        courseCode = "",
+        courseType = "",
+    )
+}


### PR DESCRIPTION
关掉 #41 #42 #43 #44 #45，并发 4.9.0。

## 修的

**#44 开学前夕日程页显示「学期已结束」** — 两层原因叠在一起：`(daysBetween / 7) + 1` 对负数向零截断，开学前 1~6 天算出周次 1 而不是 0；`totalWeeks` 由 `weekBits` 推出，开学前教务还没发课表时是 0，而 0 是"不知道"不是"零周"，旧逻辑直接比 `rawWeek > totalWeeks` 就判成学期结束。新增 `TermWeeks` 收口这段算法（floorDiv、周次锚到开学那周周一、未知时不提示），日程页原本抄了三份、小部件和屁岱各一份，一并换掉。带单元测试。

**#42 图书馆只有兴庆** — `filterScount` 拿兴庆那张手抄的区域表当白名单，另外两个校区的区域码一个都不在表里，被整体滤掉。现在校区和楼层码写死（学校侧固定枚举），区域名改成每层现拉 `/qspace`。校区 ID 与楼层码取自 [yan-xiaoo/XJTUToolBox](https://github.com/yan-xiaoo/XJTUToolBox) 的实测。

**#43 DeepSeek 思考参数族** — 补 `low` 档（官方族是 none/low/high/max）；关思考同时下发 `reasoning_effort=none`，该字段顶层与 `thinking` 对象两处都写（中转常只认一处）；默认模型改 `deepseek-flash`（`deepseek-v4-flash` 模型已退役）。"切换后"那个是 `promptSignature` 漏了 model/provider，换完模型 system prompt 里的模型 ID 还是旧的。

**#41 小部件** — 两个 layout 原本逐字节相同，4×2 的头部吃掉近 90dp，一屏只剩一条课，宽出来的两格完全没用上。按 issue 里给的参考重做成左栏今天、右栏明天，3+3 节；2×2 隐掉重复的周次翻页和更新时间戳，标题这才放得下「日程」两个字。顺带修了校历页假期里默认翻到几年前学期的问题。

**#45 仲英学辅资料** — 基于 [Guochaoo/zyxf](https://github.com/Guochaoo/zyxf) 的公开只读接口，加 `search_zyxf` / `browse_zyxf` / `read_zyxf_file` 三个工具，检索结果同时给一张可操作卡片，点文件直接下载。按 issue 里的判断没接 pdf_reader。

## 顺带

- **屁岱能看图**：相册选图（不需要读存储权限），本地压到 1300 再上传，`ImageDecoder` 自动按 EXIF 摆正，历史只留最近 2 轮的图。
- 删掉 4.8.6 的 `issues = listOf("39")` —— 它被渲染成「已知问题 • 39」，而 #39 正是 4.8.6 修好的那个。
- README 去图重写、补上 LICENSE 文件（之前只有徽章没有文件）。

## 要点确认

**4×2 上的翻周／翻天按钮全删了。** 参考图里没有，而那几个 pill 加「更新 HH:mm」正是让三节课只显示一节的原因，不删腾不出两栏。翻页保留在 2×2 和应用内。要是觉得 4×2 还得能翻，我加回去（代价是回到每栏 2 条）。

**切校区会写账号资料。** `rplace` 是账号级字段不是查询参数，学校只给了这一条路。所以只在用户点校区标签时切、绝不后台自动切，提交时把邮箱电话原样回填（少字段服务端会清空）。

## 验证

`assembleDebug` + `testDebugUnitTest` 通过，debug 包已在真机装过，启动与小部件刷新无异常日志。座位页三校区切换、屁岱发图、资料卡下载建议在真机再走一遍。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
